### PR TITLE
Fix production healthcheck and Reverb websocket defaults

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y libpq-dev \
 RUN pecl install redis \
     && docker-php-ext-enable redis
 
+# Фиксируем production PHP-настройки в репозитории, чтобы деплой не зависел от ручных правок на VPS
+COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+COPY uploads.ini /usr/local/etc/php/conf.d/uploads.ini
+
 # Устанавливаем Composer v2.9.7
 COPY --from=composer:2.9.7 /usr/bin/composer /usr/bin/composer
 
@@ -38,9 +42,3 @@ RUN sed -i 's/^pm.max_children = .*/pm.max_children = 20/' /usr/local/etc/php-fp
     && sed -i 's/^pm.start_servers = .*/pm.start_servers = 4/' /usr/local/etc/php-fpm.d/www.conf \
     && sed -i 's/^pm.min_spare_servers = .*/pm.min_spare_servers = 2/' /usr/local/etc/php-fpm.d/www.conf \
     && sed -i 's/^pm.max_spare_servers = .*/pm.max_spare_servers = 8/' /usr/local/etc/php-fpm.d/www.conf
-
-# --- СУПЕР-ОПТИМИЗАЦИЯ PHP 8.4 ---
-# Включаем OPcache и JIT (Just-In-Time) компиляцию для экстремального ускорения Laravel
-RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
-    && echo "opcache.jit_buffer_size=100M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
-    && echo "opcache.jit=tracing" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,10 +20,6 @@ RUN apt-get update && apt-get install -y libpq-dev \
 RUN pecl install redis \
     && docker-php-ext-enable redis
 
-# Фиксируем production PHP-настройки в репозитории, чтобы деплой не зависел от ручных правок на VPS
-COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
-COPY uploads.ini /usr/local/etc/php/conf.d/uploads.ini
-
 # Устанавливаем Composer v2.9.7
 COPY --from=composer:2.9.7 /usr/bin/composer /usr/bin/composer
 
@@ -42,3 +38,9 @@ RUN sed -i 's/^pm.max_children = .*/pm.max_children = 20/' /usr/local/etc/php-fp
     && sed -i 's/^pm.start_servers = .*/pm.start_servers = 4/' /usr/local/etc/php-fpm.d/www.conf \
     && sed -i 's/^pm.min_spare_servers = .*/pm.min_spare_servers = 2/' /usr/local/etc/php-fpm.d/www.conf \
     && sed -i 's/^pm.max_spare_servers = .*/pm.max_spare_servers = 8/' /usr/local/etc/php-fpm.d/www.conf
+
+# --- СУПЕР-ОПТИМИЗАЦИЯ PHP 8.4 ---
+# Включаем OPcache и JIT (Just-In-Time) компиляцию для экстремального ускорения Laravel
+RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
+    && echo "opcache.jit_buffer_size=100M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
+    && echo "opcache.jit=tracing" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini

--- a/default.conf
+++ b/default.conf
@@ -68,8 +68,14 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    # 2.5. Laravel health endpoint must bypass the SPA shell
+    # 2.5. Health endpoints must bypass the SPA shell
     location = /up {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location = /health {
         access_log off;
         default_type text/plain;
         return 200 "ok\n";

--- a/src/echo.js
+++ b/src/echo.js
@@ -3,14 +3,17 @@ import Pusher from 'pusher-js';
 
 window.Pusher = Pusher;
 
+const isSecure = window.location.protocol === 'https:';
+const reverbPort = Number(import.meta.env.VITE_REVERB_PORT || (isSecure ? 443 : 80));
+
 const echo = new Echo({
     broadcaster: 'reverb',
     key: import.meta.env.VITE_REVERB_APP_KEY || 'mercasto_key',
     wsHost: import.meta.env.VITE_REVERB_HOST || window.location.hostname,
-    wsPort: import.meta.env.VITE_REVERB_PORT || 8082,
-    wssPort: import.meta.env.VITE_REVERB_PORT || 8082,
-    forceTLS: false,
-    enabledTransports: ['ws', 'wss'],
+    wsPort: reverbPort,
+    wssPort: reverbPort,
+    forceTLS: isSecure,
+    enabledTransports: isSecure ? ['wss'] : ['ws'],
 });
 
 export default echo;


### PR DESCRIPTION
## Summary
- Adds an explicit `/health` Nginx endpoint that returns `200 ok`, matching the existing frontend Docker healthcheck without changing `docker-compose.yml`.
- Updates the Laravel Echo/Reverb client defaults so production HTTPS uses secure WebSockets (`wss`) on port `443` instead of trying the internal Reverb port `8082`.

## Notes
- No database, Docker service, package, or server runtime changes are included.
- I intentionally avoided changing `docker-compose.yml` and PHP ini files in this PR after tool safety checks blocked those writes; this PR stays limited to safe, small production compatibility fixes.

## Smoke tests after deploy
- `https://mercasto.com/` should return `200`.
- `https://mercasto.com/health` should return `200 ok`.
- `https://mercasto.com/up` should still return `200 ok`.
- `/api/categories`, `/api/ads?page=1`, `/api/auth/providers` should remain `200`.
- Reverb WebSocket via `/app/{key}` should continue returning `101 Switching Protocols`.