### PR TITLE
Add nginx health endpoint

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -68,8 +68,14 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    # 2.5. Laravel health endpoint must bypass the SPA shell
+    # 2.5. Health endpoints must bypass the SPA shell
     location = /up {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location = /health {
         access_log off;
         default_type text/plain;
         return 200 "ok\n";


### PR DESCRIPTION
## Summary
Adds a dedicated /health endpoint in nginx alongside /up so container health checks can hit a route that bypasses the React SPA shell.

## Risk
Low. Nginx config adds a static health response only. No database, application logic, Docker services, or secrets changed.

## Smoke tests
After deploy:
- curl -sS https://mercasto.com/health
- curl -sS https://mercasto.com/up
- curl -I https://mercasto.com/

## Rollback
Revert this PR to remove the /health location.