### PR TITLE
Add MVP verticals brief

### DIFF
--- a/docs/product/VERTICALS_MVP_BRIEF.md
+++ b/docs/product/VERTICALS_MVP_BRIEF.md
@@ -1,0 +1,103 @@
+# Mercasto Verticals MVP Brief
+
+Owner: CPO Agent + Project Manager Agent
+
+Purpose: define the first vertical focus areas inside the single Mercasto marketplace.
+
+## Strategy
+
+Mercasto stays one platform with shared users, search, publishing, moderation, and seller dashboard.
+
+Initial verticals:
+
+1. Autos
+2. Services
+
+## Autos MVP
+
+Goal: make vehicle listings easier to browse and publish.
+
+MVP fields:
+
+- make
+- model
+- year
+- price
+- mileage
+- transmission
+- condition
+- location
+- photos
+
+MVP filters:
+
+- location
+- price
+- make
+- model
+- year
+- mileage
+- transmission
+
+MVP UI:
+
+- Autos landing page
+- vehicle-specific listing card
+- detail page with structured fields
+- publish flow fields
+- clear contact action
+
+## Services MVP
+
+Goal: make local service providers easier to find and contact.
+
+MVP fields:
+
+- service type
+- area served
+- price from
+- experience
+- photos of work
+- description
+- location
+- contact method
+
+MVP filters:
+
+- location
+- service type
+- rating or trust marker later
+- price range later
+
+MVP UI:
+
+- Services landing page
+- provider card
+- provider detail page
+- work photo gallery
+- clear contact action
+
+## Shared requirements
+
+- Mobile-first layout
+- Empty states
+- Loading states
+- Spanish copy for Mexico
+- Report action
+- Seller trust marker when available
+- SEO-ready URL structure
+
+## Acceptance criteria
+
+- Each vertical has a landing page plan.
+- Each vertical has required fields listed.
+- Each vertical has filters listed.
+- Each vertical has card/detail requirements.
+- Follow-up implementation issues are created.
+
+## Not in MVP
+
+- Separate mobile apps
+- Separate domains
+- Complex subscription logic
+- Large refactors without QA coverage


### PR DESCRIPTION
## Summary
Adds an MVP brief for the first Mercasto verticals: Autos and Services.

## Risk
Low. Documentation only. No runtime behavior, database, deployment, or credentials changed.

## Smoke tests
Not required for documentation.

## Rollback
Revert this PR to remove the brief.