### PR TITLE
Track page and homepage views

### DIFF
--- a/src/components/common/AnalyticsRouteTracker.jsx
+++ b/src/components/common/AnalyticsRouteTracker.jsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { trackEvent, trackPageView } from '../../lib/analytics';
+
+export default function AnalyticsRouteTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const page = location.pathname || '/';
+
+    trackPageView(page);
+
+    if (page === '/') {
+      trackEvent('homepage_viewed', {
+        page: '/',
+        source: 'route',
+      });
+    }
+  }, [location.pathname]);
+
+  return null;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import AppWrapper from './App.jsx'
+import AnalyticsRouteTracker from './components/common/AnalyticsRouteTracker.jsx'
 import './index.css'
 
 const rootElement = document.getElementById('root');
@@ -9,6 +10,7 @@ if (rootElement) {
   createRoot(rootElement).render(
     <React.StrictMode>
       <BrowserRouter>
+        <AnalyticsRouteTracker />
         <AppWrapper />
       </BrowserRouter>
     </React.StrictMode>


### PR DESCRIPTION
## Summary
Adds a small route tracker component that emits page view and homepage view events through the safe analytics helper.

## Risk
Medium-low. Frontend-only change. No backend, database, deployment, payment, auth, or credential changes. The tracker renders null and should not affect layout.

## Smoke tests
- Run frontend build/lint.
- Open homepage and confirm no blank screen.
- Navigate between routes and confirm app still renders.
- With VITE_ANALYTICS_DEBUG=true, confirm page/homepage events appear in the console.

## Rollback
Revert this PR to remove the tracker component and its import from main.jsx.