### PR TITLE
Hotfix rollback route analytics tracker

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import AppWrapper from './App.jsx'
-import AnalyticsRouteTracker from './components/common/AnalyticsRouteTracker.jsx'
 import './index.css'
 
 const rootElement = document.getElementById('root');
@@ -10,7 +9,6 @@ if (rootElement) {
   createRoot(rootElement).render(
     <React.StrictMode>
       <BrowserRouter>
-        <AnalyticsRouteTracker />
         <AppWrapper />
       </BrowserRouter>
     </React.StrictMode>


### PR DESCRIPTION
## Summary
Rolls back the runtime import and mount of AnalyticsRouteTracker from main.jsx while keeping the analytics helper files for later review.

## Risk
Low. Frontend-only rollback of the latest runtime wiring. No backend, database, deployment, payment, auth, or credential changes.

## Smoke tests
- Open https://mercasto.com on iOS Safari and Chrome after deploy.
- Confirm homepage renders and is not blank.
- Run npm run smoke:prod after deploy.

## Rollback
Revert this PR to re-enable the route tracker.