### PR TITLE
Auto-run emergency SSH frontend deploy

### DIFF
--- a/.github/workflows/emergency-ssh-frontend-deploy.yml
+++ b/.github/workflows/emergency-ssh-frontend-deploy.yml
@@ -1,0 +1,97 @@
+name: Emergency SSH Frontend Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: emergency-ssh-frontend-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy frontend over SSH
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Validate required secrets
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          test -n "$SERVER_SSH_KEY"
+
+      - name: Install SSH key
+        shell: bash
+        env:
+          SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SERVER_SSH_KEY" > ~/.ssh/mercasto_deploy_key
+          chmod 600 ~/.ssh/mercasto_deploy_key
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+
+      - name: Deploy frontend
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/mercasto_deploy_key "$SERVER_USER@$SERVER_HOST" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+
+          candidates=(
+            "$HOME/mercasto"
+            "/root/mercasto"
+            "/var/www/mercasto"
+            "/opt/mercasto"
+            "/srv/mercasto"
+          )
+
+          project_dir=""
+          for dir in "${candidates[@]}"; do
+            if [ -f "$dir/docker-compose.yml" ] && [ -d "$dir/.git" ]; then
+              project_dir="$dir"
+              break
+            fi
+          done
+
+          if [ -z "$project_dir" ]; then
+            found=$(find /root /var/www /opt /srv "$HOME" -maxdepth 3 -name docker-compose.yml -print 2>/dev/null | head -1 || true)
+            if [ -n "$found" ]; then
+              project_dir=$(dirname "$found")
+            fi
+          fi
+
+          if [ -z "$project_dir" ] || [ ! -d "$project_dir/.git" ]; then
+            echo "Mercasto project directory was not found."
+            exit 1
+          fi
+
+          cd "$project_dir"
+          git fetch origin main
+          git reset --hard origin/main
+          docker compose build --no-cache mercasto-frontend
+          docker compose up -d mercasto-frontend
+          docker compose ps
+          REMOTE
+
+      - name: Smoke check
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -I --max-time 30 https://mercasto.com/
+          curl -sS --max-time 30 https://mercasto.com/api/categories | head -c 300


### PR DESCRIPTION
## Summary
Allows the emergency SSH frontend deploy workflow to run automatically on pushes to main.

## Risk
Medium. Deploy workflow only. It rebuilds and restarts only the frontend service.

## Smoke tests
Workflow performs HTTP checks after deploy.

## Rollback
Revert this PR.