### PR TITLE
Auto-run emergency SSH frontend deploy v2

### DIFF
--- a/.github/workflows/emergency-ssh-frontend-deploy.yml
+++ b/.github/workflows/emergency-ssh-frontend-deploy.yml
@@ -2,6 +2,9 @@ name: Emergency SSH Frontend Deploy
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Allows the emergency SSH frontend deploy workflow to run automatically on pushes to main.

## Risk
Medium. Deploy workflow only. It rebuilds and restarts only the frontend service.

## Smoke tests
Workflow performs HTTP checks after deploy.

## Rollback
Revert this PR.