### PR TITLE
Disable broken AI workflows during recovery

### DIFF
--- a/.github/workflows/ai-factory-audit.yml
+++ b/.github/workflows/ai-factory-audit.yml
@@ -1,1 +1,14 @@
+name: Disabled AI Factory Audit
 
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  disabled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disabled
+        run: echo "AI factory audit workflow is disabled during production recovery."

--- a/.github/workflows/ai-model-deploy.yml
+++ b/.github/workflows/ai-model-deploy.yml
@@ -1,44 +1,14 @@
-mkdir -p .github/workflows
-cat > .github/workflows/ai-model-deploy.yml << 'YML'
-name: Deploy AI Model
+name: Disabled AI Model Deploy
 
 on:
   workflow_dispatch:
-    inputs:
-      model:
-        description: 'Ollama model'
-        required: true
-        default: 'qwen2.5:1.5b'
+
+permissions:
+  contents: read
 
 jobs:
-  deploy:
+  disabled:
     runs-on: ubuntu-latest
     steps:
-      - name: SSH Deploy
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: root
-          key: ${{ secrets.SSH_KEY }}
-          script: |
-            set -e
-            cd /var/www/mercasto
-            
-            echo "▶ Pull model ${{ github.event.inputs.model }}"
-            docker exec mercasto_ollama ollama pull ${{ github.event.inputs.model }}
-            
-            echo "▶ Update AiService.php"
-            sed -i -E "s/'model' => '[^']+'/'model' => '${{ github.event.inputs.model }}'/" backend/app/Services/AiService.php
-            
-            echo "▶ Restart backend"
-            docker compose restart mercasto-backend
-            sleep 5
-            
-            echo "▶ Warmup"
-            docker exec mercasto_ollama ollama run ${{ github.event.inputs.model }} "warmup" --keepalive 24h > /dev/null 2>&1 &
-            
-            echo "▶ Test"
-            curl -s https://mercasto.com/api/ai/describe -d "title=Test" -d "category=General" | jq -r .text | head -c 100
-            
-            docker exec mercasto_ollama ollama ps
-YML
+      - name: Disabled
+        run: echo "AI model deploy workflow is disabled during production recovery."

--- a/docs/archived-workflows/ai-model-deploy.yml.txt
+++ b/docs/archived-workflows/ai-model-deploy.yml.txt
@@ -1,0 +1,27 @@
+mkdir -p .github/workflows
+cat > .github/workflows/ai-model-deploy.yml << 'YML'
+name: Deploy AI Model
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: 'Ollama model'
+        required: true
+        default: 'qwen2.5:1.5b'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH Deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: root
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -e
+            cd /var/www/mercasto
+            docker exec mercasto_ollama ollama pull ${{ github.event.inputs.model }}
+YML


### PR DESCRIPTION
## Summary
Disables two broken AI workflows during production recovery by making them manual-only no-op workflows.

## Risk
Low. CI-only change. No runtime, backend, database, payment, or deploy logic changed.

## Smoke tests
Actions should stop showing these workflows as failing on every push.

## Rollback
Revert this PR to restore the previous workflow files.