### PR TITLE
Disable self-hosted deploy on push during recovery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy Mercasto Frontend Hotfix
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
Disables the self-hosted deploy workflow from running on every push during production recovery. It remains available manually.

## Risk
Low. CI trigger change only. Runtime code is unchanged.

## Smoke tests
Only the emergency SSH deploy should run automatically on the next push.

## Rollback
Revert this PR.