### PR TITLE
Trigger emergency SSH deploy after secrets fix

### DIFF
--- a/public/deploy-trigger.txt
+++ b/public/deploy-trigger.txt
@@ -1,1 +1,1 @@
-frontend deploy trigger 2026-04-25T13:25Z
+frontend deploy trigger 2026-04-25T14:03Z


### PR DESCRIPTION
## Summary
Updates the deploy trigger marker after fixing emergency SSH deploy secrets.

## Risk
Low. Static marker file only.

## Smoke tests
Emergency SSH deploy should run after merge.

## Rollback
Revert this PR.