### PR TITLE
Auto-run container frontend patch on trigger

### DIFF
--- a/.github/workflows/emergency-container-frontend-patch.yml
+++ b/.github/workflows/emergency-container-frontend-patch.yml
@@ -2,6 +2,11 @@ name: Emergency Container Frontend Patch
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'public/deploy-trigger.txt'
 
 permissions:
   contents: read

--- a/public/deploy-trigger.txt
+++ b/public/deploy-trigger.txt
@@ -1,1 +1,1 @@
-frontend deploy trigger 2026-04-25T14:03Z
+frontend deploy trigger 2026-04-26T06:22Z


### PR DESCRIPTION
## Summary
Allows the container frontend patch workflow to run automatically only when the deploy trigger marker changes.

## Risk
Medium. Frontend static patch workflow only.

## Smoke tests
Workflow performs HTTP checks.

## Rollback
Revert this PR.