### PR TITLE
Fix iOS Notification runtime crash

### DIFF
--- a/src/lib/notificationPolyfill.js
+++ b/src/lib/notificationPolyfill.js
@@ -1,0 +1,14 @@
+const fallbackNotification = function fallbackNotification() {
+  return null;
+};
+
+fallbackNotification.permission = 'denied';
+fallbackNotification.requestPermission = () => Promise.resolve('denied');
+
+if (typeof globalThis !== 'undefined' && typeof globalThis.Notification === 'undefined') {
+  Object.defineProperty(globalThis, 'Notification', {
+    value: fallbackNotification,
+    configurable: true,
+    writable: false,
+  });
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+import './lib/notificationPolyfill.js'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'


### PR DESCRIPTION
## Summary
Adds a small Notification polyfill before React boots so iOS/Safari does not crash when Notification is unavailable.

## Risk
Low. Frontend-only compatibility fix.

## Smoke tests
Build frontend and open the site on iOS Safari/Chrome.

## Rollback
Revert this PR.