### PR TITLE
Stabilize deploy workflows after recovery

### DIFF
--- a/.github/workflows/emergency-container-frontend-patch.yml
+++ b/.github/workflows/emergency-container-frontend-patch.yml
@@ -2,11 +2,6 @@ name: Emergency Container Frontend Patch
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'public/deploy-trigger.txt'
 
 permissions:
   contents: read

--- a/.github/workflows/emergency-ssh-frontend-deploy.yml
+++ b/.github/workflows/emergency-ssh-frontend-deploy.yml
@@ -1,4 +1,4 @@
-name: Disabled Emergency SSH Frontend Deploy
+name: Emergency SSH Frontend Deploy
 
 on:
   workflow_dispatch:
@@ -6,9 +6,90 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: emergency-ssh-frontend-deploy
+  cancel-in-progress: true
+
 jobs:
-  disabled:
+  deploy:
+    name: Deploy frontend over SSH
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - name: Disabled during recovery
-        run: echo "SSH deploy is disabled during recovery. Use Emergency Container Frontend Patch instead."
+      - name: Validate required secrets
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: root
+          SERVER_SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          test -n "$SERVER_SSH_KEY"
+
+      - name: Install SSH key
+        shell: bash
+        env:
+          SERVER_SSH_KEY: ${{ secrets.SSH_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SERVER_SSH_KEY" > ~/.ssh/mercasto_deploy_key
+          chmod 600 ~/.ssh/mercasto_deploy_key
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+
+      - name: Deploy frontend
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: root
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/mercasto_deploy_key "$SERVER_USER@$SERVER_HOST" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+
+          candidates=(
+            "$HOME/mercasto"
+            "/root/mercasto"
+            "/var/www/mercasto"
+            "/opt/mercasto"
+            "/srv/mercasto"
+          )
+
+          project_dir=""
+          for dir in "${candidates[@]}"; do
+            if [ -f "$dir/docker-compose.yml" ] && [ -d "$dir/.git" ]; then
+              project_dir="$dir"
+              break
+            fi
+          done
+
+          if [ -z "$project_dir" ]; then
+            found=$(find /root /home /var/www /opt /srv "$HOME" -maxdepth 4 -name docker-compose.yml -print 2>/dev/null | head -1 || true)
+            if [ -n "$found" ]; then
+              project_dir=$(dirname "$found")
+            fi
+          fi
+
+          if [ -z "$project_dir" ] || [ ! -d "$project_dir/.git" ]; then
+            echo "Mercasto project directory was not found."
+            exit 1
+          fi
+
+          cd "$project_dir"
+          git fetch origin main
+          git reset --hard origin/main
+          docker compose build --no-cache mercasto-frontend
+          docker compose up -d mercasto-frontend
+          docker compose ps
+          REMOTE
+
+      - name: Smoke check
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -I --max-time 30 https://mercasto.com/
+          curl -sS --max-time 30 https://mercasto.com/ | head -c 500
+          curl -sS --max-time 30 https://mercasto.com/api/categories | head -c 300

--- a/docs/ops/DEPLOY_WORKFLOWS.md
+++ b/docs/ops/DEPLOY_WORKFLOWS.md
@@ -1,0 +1,76 @@
+# Mercasto Deploy Workflows
+
+This document records the safe workflow setup after the iOS production recovery.
+
+## Current production status
+
+- Mercasto opens on iOS Safari/Chrome.
+- `/api/categories` responds correctly.
+- The white-screen crash was resolved by the inline `Notification` fallback in `index.html` and the pre-React polyfill in `src/lib/notificationPolyfill.js`.
+
+## Primary manual deploy path
+
+Use this workflow for frontend production deploys:
+
+```text
+Emergency SSH Frontend Deploy
+```
+
+Expected secrets:
+
+```text
+SERVER_HOST
+SSH_KEY
+```
+
+Important:
+
+- `SERVER_HOST` should be the IPv4 address when DNS resolves to an unreachable IPv6 address.
+- The workflow deploys only the frontend container.
+- It does not run database migrations.
+
+## Reserve workflows
+
+### Emergency Container Frontend Patch
+
+Manual-only reserve workflow.
+
+Use only if SSH is unavailable but the self-hosted runner is healthy.
+
+Known failure mode:
+
+```text
+Could not find file '/tmp/runner/_temp'
+```
+
+That means the self-hosted runner is broken before job steps start. In that case, do not use this workflow until the runner is repaired.
+
+### Deploy Mercasto Frontend Hotfix
+
+Manual-only self-hosted deploy workflow.
+
+Do not use while the self-hosted runner is unstable.
+
+### Emergency Frontend Deploy
+
+Legacy manual-only self-hosted deploy workflow.
+
+Do not use unless the self-hosted runner has been repaired and the main SSH deploy is unavailable.
+
+## Disabled workflows
+
+These are intentionally disabled or no-op during recovery:
+
+- AI Model Deploy
+- AI Factory Audit
+
+Do not re-enable AI or model workflows until production deploy is stable and verified.
+
+## Rule after recovery
+
+Do not add automatic production deploys on every push until:
+
+1. self-hosted runner health is fixed;
+2. the deploy path is tested at least once manually;
+3. frontend smoke checks pass on iOS Safari and Chrome;
+4. workflows are reduced to one standard deploy and one emergency fallback.


### PR DESCRIPTION
## Summary
Stabilizes deploy workflows after the iOS production recovery:
- makes the container frontend patch workflow manual-only;
- restores SSH frontend deploy as a manual workflow only;
- documents which workflow to use and which workflows are reserve/disabled.

## Risk
Low-medium. CI/workflow/docs only. No app runtime, backend, database, migrations, payment, or UI changes.

## Smoke tests
No runtime smoke needed for docs/workflow trigger cleanup. Production site is already opening on iOS.

## Rollback
Revert this PR to restore the previous workflow trigger setup.