### PR TITLE
Add stabilization backlog

### DIFF
--- a/.github/workflows/ai-autopilot.yml
+++ b/.github/workflows/ai-autopilot.yml
@@ -1,36 +1,14 @@
-name: AI Autopilot
+name: Disabled AI Autopilot
 
 on:
   workflow_dispatch:
-    inputs:
-      model:
-        description: 'Model'
-        default: 'qwen2.5:1.5b'
-        type: choice
-        options: [qwen2.5:1.5b, qwen2.5:3b, mistral:7b]
+
+permissions:
+  contents: read
 
 jobs:
-  deploy-ai:
-    runs-on: self-hosted
-
+  disabled:
+    runs-on: ubuntu-latest
     steps:
-      - name: Установить модель
-        run: |
-          MODEL="${{ inputs.model }}"
-          OLLAMA=$(docker ps --format '{{.Names}}' | grep ollama)
-          BACKEND=$(docker ps --format '{{.Names}}' | grep backend)
-
-          echo "▶ Pull $MODEL"
-          docker exec $OLLAMA ollama pull $MODEL
-
-          echo "▶ Обновить код"
-          AI=$(docker exec $BACKEND find /var/www -name AiService.php | head -1)
-          docker exec $BACKEND sed -i "s/'model' => '[^']*'/'model' => '$MODEL'/g" $AI
-
-          docker restart $OLLAMA $BACKEND
-          sleep 8
-
-          echo "✅ $MODEL готов"
-          curl -s -X POST https://mercasto.com/api/ai/describe \
-            -H "Content-Type: application/json" \
-            -d '{"title":"Test","category":"Test"}' | jq.
+      - name: Disabled during stabilization
+        run: echo "AI Autopilot is disabled until runner health, deploy secrets, and production smoke checks are verified."

--- a/docs/ops/STABILIZATION_BACKLOG.md
+++ b/docs/ops/STABILIZATION_BACKLOG.md
@@ -1,0 +1,5 @@
+# Mercasto Stabilization Backlog
+
+Purpose: define what remains before returning to normal feature development.
+
+## Current stable

--- a/docs/ops/STABILIZATION_BACKLOG.md
+++ b/docs/ops/STABILIZATION_BACKLOG.md
@@ -2,4 +2,60 @@
 
 Purpose: define what remains before returning to normal feature development.
 
-## Current stable
+## Current stable state
+
+- Mercasto opens on iOS Safari and Chrome.
+- API category endpoint returns JSON.
+- The iOS `Notification` runtime crash has been patched.
+- Production deploy workflows have been reduced to manual paths.
+- Runner health and secret rotation are tracked in separate issues.
+
+## Completed recovery items
+
+- Restored frontend boot on iOS.
+- Added inline `Notification` fallback in `index.html`.
+- Added pre-React `Notification` fallback in `src/lib/notificationPolyfill.js`.
+- Added deploy workflow runbook.
+- Added post-recovery smoke checklist.
+- Added runner health runbook.
+- Added secret rotation checklist.
+- Disabled or reduced noisy workflows during stabilization.
+
+## Open stabilization tasks
+
+1. Complete smoke validation from issue #77.
+2. Repair server GitHub runner from issue #75.
+3. Rotate exposed deploy SSH credential from issue #79.
+4. Confirm `SERVER_HOST` uses IPv4 while IPv6 routing is unreliable.
+5. Verify the manual SSH frontend deploy works with the rotated credential.
+6. Decide whether to keep or remove reserve server-runner workflows after runner repair.
+7. Keep AI/model workflows disabled until deploy and runner health are stable.
+
+## Return-to-feature-development gate
+
+Resume UI, analytics, AI, monetization, and large refactors only after:
+
+- smoke checklist passes;
+- runner repair is complete or server-runner workflows are removed;
+- exposed deploy credential is rotated;
+- one manual frontend deploy is verified with the new credential;
+- Actions page is readable and not flooded with unrelated failures.
+
+## Feature work currently paused
+
+- analytics wiring beyond safe helper files;
+- auto-apply/auto-accept automation;
+- AI model deployment workflows;
+- large UI refactors;
+- database schema changes;
+- payment or monetization changes;
+- production security hardening that requires server changes.
+
+## Safe work allowed during stabilization
+
+- documentation;
+- issue grooming;
+- small CI trigger cleanup;
+- non-runtime runbooks;
+- smoke test tracking;
+- planning tasks for later implementation.


### PR DESCRIPTION
## Summary
Adds a stabilization backlog and disables AI Autopilot during stabilization.

## Risk
Low. Documentation and CI safety only. No runtime, deploy, database, payment, or frontend behavior changes.

## Follow-up
Created issue #81 to track the stabilization gate before feature work resumes.

## Rollback
Revert this PR to restore the previous notes/workflow state.