### PR TITLE
Add recovery guard checks

### DIFF
--- a/.github/workflows/recovery-guard.yml
+++ b/.github/workflows/recovery-guard.yml
@@ -1,0 +1,29 @@
+name: Recovery Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'index.html'
+      - 'src/main.jsx'
+      - 'src/lib/notificationPolyfill.js'
+      - '.github/workflows/emergency-container-frontend-patch.yml'
+      - '.github/workflows/emergency-ssh-frontend-deploy.yml'
+      - 'scripts/check-recovery-guards.mjs'
+      - 'package.json'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run recovery guard checks
+        run: npm run check:recovery

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "start:server": "node server/index.js",
     "smoke:prod": "bash scripts/smoke-test.sh",
-    "smoke": "bash scripts/smoke-test.sh"
+    "smoke": "bash scripts/smoke-test.sh",
+    "check:recovery": "node scripts/check-recovery-guards.mjs"
   },
   "dependencies": {
     "@sentry/react": "^10.49.0",

--- a/scripts/check-recovery-guards.mjs
+++ b/scripts/check-recovery-guards.mjs
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+
+const checks = [];
+
+function read(path) {
+  return readFileSync(path, 'utf8');
+}
+
+function assertContains(path, needle, reason) {
+  const content = read(path);
+  if (!content.includes(needle)) {
+    throw new Error(`${path} must contain ${JSON.stringify(needle)}: ${reason}`);
+  }
+  checks.push(`${path}: ${reason}`);
+}
+
+function assertNotContains(path, needle, reason) {
+  const content = read(path);
+  if (content.includes(needle)) {
+    throw new Error(`${path} must not contain ${JSON.stringify(needle)}: ${reason}`);
+  }
+  checks.push(`${path}: ${reason}`);
+}
+
+assertContains(
+  'index.html',
+  "typeof window.Notification === 'undefined'",
+  'inline Notification fallback protects iOS browsers before the app bundle loads'
+);
+
+assertContains(
+  'src/main.jsx',
+  "./lib/notificationPolyfill.js",
+  'pre-React Notification fallback is loaded before App.jsx'
+);
+
+assertContains(
+  'src/lib/notificationPolyfill.js',
+  'fallbackNotification.requestPermission',
+  'Notification fallback exposes requestPermission safely'
+);
+
+assertNotContains(
+  '.github/workflows/emergency-container-frontend-patch.yml',
+  "paths:\n      - 'public/deploy-trigger.txt'",
+  'container patch workflow must stay manual-only during stabilization'
+);
+
+assertContains(
+  '.github/workflows/emergency-ssh-frontend-deploy.yml',
+  'workflow_dispatch',
+  'SSH frontend deploy remains manually triggerable'
+);
+
+assertNotContains(
+  '.github/workflows/emergency-ssh-frontend-deploy.yml',
+  'push:',
+  'SSH frontend deploy must not auto-run on every push during stabilization'
+);
+
+console.log('Recovery guard checks passed:');
+for (const check of checks) {
+  console.log(`- ${check}`);
+}


### PR DESCRIPTION
## Summary
Adds static recovery guard checks to prevent accidental removal of the iOS Notification fallbacks or re-enabling deploy workflows on push during stabilization.

## Risk
Low. QA/CI only. No production deploy, database, payment, backend, or UI behavior changes.

## Checks
- `npm run check:recovery`
- PR-only Recovery Guard workflow

## Rollback
Revert this PR to remove the guard script and workflow.