### PR TITLE
Add frontend quality gate

### DIFF
--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -1,0 +1,41 @@
+name: Frontend Quality Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'index.html'
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.*'
+      - 'tailwind.config.*'
+      - '.github/workflows/frontend-quality.yml'
+      - 'scripts/check-recovery-guards.mjs'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Build and recovery checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run recovery guards
+        run: npm run check:recovery
+      - name: Build frontend
+        run: npm run build

--- a/docs/ops/STABILIZATION_BACKLOG.md
+++ b/docs/ops/STABILIZATION_BACKLOG.md
@@ -19,6 +19,7 @@ Purpose: define what remains before returning to normal feature development.
 - Added post-recovery smoke checklist.
 - Added runner health runbook.
 - Added secret rotation checklist.
+- Added PR-only frontend quality gate for build and recovery guard checks.
 - Disabled or reduced noisy workflows during stabilization.
 
 ## Open stabilization tasks
@@ -39,7 +40,8 @@ Resume UI, analytics, AI, monetization, and large refactors only after:
 - runner repair is complete or server-runner workflows are removed;
 - exposed deploy credential is rotated;
 - one manual frontend deploy is verified with the new credential;
-- Actions page is readable and not flooded with unrelated failures.
+- Actions page is readable and not flooded with unrelated failures;
+- frontend PR quality gate is green on new frontend changes.
 
 ## Feature work currently paused
 
@@ -58,4 +60,5 @@ Resume UI, analytics, AI, monetization, and large refactors only after:
 - small CI trigger cleanup;
 - non-runtime runbooks;
 - smoke test tracking;
-- planning tasks for later implementation.
+- planning tasks for later implementation;
+- PR-only quality checks that do not deploy production.


### PR DESCRIPTION
## Summary
Adds a PR-only frontend quality workflow that installs dependencies, runs recovery guard checks, and builds the frontend.

## Risk
Low. CI only. No production deploy, server runner, database, payment, backend, or UI runtime changes.

## Checks
- `npm ci`
- `npm run check:recovery`
- `npm run build`

## Rollback
Revert this PR to remove the frontend quality workflow and backlog note.