### PR TITLE
Disable server-runner frontend patch workflow

### DIFF
--- a/.github/workflows/emergency-container-frontend-patch.yml
+++ b/.github/workflows/emergency-container-frontend-patch.yml
@@ -1,4 +1,4 @@
-name: Emergency Container Frontend Patch
+name: Disabled Emergency Container Frontend Patch
 
 on:
   workflow_dispatch:
@@ -6,42 +6,9 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: emergency-container-frontend-patch
-  cancel-in-progress: true
-
 jobs:
-  patch:
-    name: Patch running frontend container
-    runs-on: [self-hosted, linux]
-    timeout-minutes: 20
+  disabled:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout current main
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Build frontend assets
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            -v "$PWD:/app" \
-            -w /app \
-            node:22-alpine \
-            sh -lc 'npm ci && npm run build'
-
-      - name: Patch frontend container files
-        run: |
-          set -euo pipefail
-          test -d dist
-          docker ps --format '{{.Names}}' | grep -qx 'mercasto_frontend_container'
-          docker exec mercasto_frontend_container sh -lc 'rm -rf /usr/share/nginx/html/*'
-          docker cp dist/. mercasto_frontend_container:/usr/share/nginx/html/
-          docker exec mercasto_frontend_container nginx -s reload
-
-      - name: Smoke check
-        run: |
-          set -euo pipefail
-          curl -I --max-time 30 https://mercasto.com/
-          curl -sS --max-time 30 https://mercasto.com/ | head -c 500
-          curl -sS --max-time 30 https://mercasto.com/api/categories | head -c 300
+      - name: Disabled until server runner is repaired
+        run: echo "Emergency Container Frontend Patch is disabled. Use Emergency SSH Frontend Deploy until server-runner health is repaired and verified."

--- a/docs/ops/STABILIZATION_BACKLOG.md
+++ b/docs/ops/STABILIZATION_BACKLOG.md
@@ -8,6 +8,7 @@ Purpose: define what remains before returning to normal feature development.
 - API category endpoint returns JSON.
 - The iOS `Notification` runtime crash has been patched.
 - Production deploy workflows have been reduced to manual paths.
+- Server-runner deploy workflows are disabled until runner health is repaired.
 - Runner health and secret rotation are tracked in separate issues.
 
 ## Completed recovery items
@@ -21,11 +22,12 @@ Purpose: define what remains before returning to normal feature development.
 - Added secret rotation checklist.
 - Added PR-only frontend quality gate for build and recovery guard checks.
 - Disabled or reduced noisy workflows during stabilization.
+- Disabled server-runner frontend patch workflow until runner health is repaired.
 
 ## Open stabilization tasks
 
 1. Complete smoke validation from issue #77.
-2. Repair server GitHub runner from issue #75.
+2. Keep server-runner workflows disabled until issue #75 is repaired and verified.
 3. Rotate exposed deploy SSH credential from issue #79.
 4. Confirm `SERVER_HOST` uses IPv4 while IPv6 routing is unreliable.
 5. Verify the manual SSH frontend deploy works with the rotated credential.
@@ -37,7 +39,7 @@ Purpose: define what remains before returning to normal feature development.
 Resume UI, analytics, AI, monetization, and large refactors only after:
 
 - smoke checklist passes;
-- runner repair is complete or server-runner workflows are removed;
+- runner repair is complete or server-runner workflows remain disabled;
 - exposed deploy credential is rotated;
 - one manual frontend deploy is verified with the new credential;
 - Actions page is readable and not flooded with unrelated failures;


### PR DESCRIPTION
## Summary
Disables the server-runner frontend patch workflow until runner health is repaired and updates the stabilization backlog.

## Risk
Low. CI safety and docs only. No production deploy, database, payment, backend, or UI runtime changes.

## Rollback
Re-enable the workflow after runner health is repaired and verified.