### PR TITLE
P0: Auto-reporter agent for smoke + deploy checks

### DIFF
--- a/.github/workflows/deploy-secret-presence-check.yml
+++ b/.github/workflows/deploy-secret-presence-check.yml
@@ -5,6 +5,10 @@ on:
 
 permissions:
   contents: read
+  issues: write
+
+env:
+  DEPLOY_SECRET_REPORT_ISSUES: "104 98 92"
 
 jobs:
   check:
@@ -36,3 +40,40 @@ jobs:
 
           echo "Required deploy secrets are present. Values were not printed."
           echo "SERVER_HOST format: IPv4"
+
+      - name: Report result to linked issues
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RESULT: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          body=$(cat <<EOF
+Agent Report: Deploy Secret Presence Check
+
+Result: ${RESULT}
+Run: ${RUN_URL}
+Timestamp: ${timestamp}
+
+Checks:
+- SERVER_HOST secret exists;
+- SSH_KEY secret exists;
+- SERVER_HOST format is IPv4 during stabilization.
+
+Failed check: see workflow logs if result is failure. Secret values are not printed.
+
+Safety boundary: secret presence/format check only; no deploy, no SSH connection, no database writes, no payment actions, no secret values printed.
+EOF
+)
+          for issue in ${DEPLOY_SECRET_REPORT_ISSUES}; do
+            curl -fsS -X POST \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${REPO}/issues/${issue}/comments" \
+              -d "$(jq -n --arg body "$body" '{body: $body}')"
+          done


### PR DESCRIPTION
Adds automatic agent reporting into P0 issues.

What this does:
- Public Smoke Check posts results into #103, #77, #98
- Deploy Secret Presence Check posts results into #104, #98, #92

Why:
- closes loop for P0 stabilization
- removes manual reporting
- keeps everything inside GitHub issues

Safety:
- read-only checks only
- no SSH, no deploy, no DB, no payments
- no secrets printed

This implements #109 (Auto-Reporter Agent).