### PR TITLE
docs: record first-party automerge behavior

### DIFF
--- a/docs/ops/AUTONOMOUS_DELIVERY_RUNBOOK.md
+++ b/docs/ops/AUTONOMOUS_DELIVERY_RUNBOOK.md
@@ -28,6 +28,8 @@ Required PR label: `automerge`
 
 Merge method: `squash`
 
+The workflow uses first-party GitHub CLI commands and the repository `GITHUB_TOKEN`. It resolves the PR number, verifies that the PR is open, non-draft, labeled `automerge`, free of blocking labels, and in a merge-ready state, then merges with `--match-head-commit` so the merge is rejected if the PR head changes after validation.
+
 The workflow relies on GitHub pull request readiness and required checks. It must not be used to bypass failing checks or unresolved blockers.
 
 ## Production verification baseline


### PR DESCRIPTION
Autonomous verification PR for the first-party automerge workflow.

Change:
- Document the current GitHub CLI-based automerge behavior.

Risk:
- Documentation only.

Expected automation:
- Label `automerge` should allow the automerge workflow to merge this PR when GitHub reports it merge-ready.