### PR TITLE
fix(media): raise PHP upload cap for video validation alignment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -76,11 +76,12 @@ RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.
     && echo "opcache.jit_buffer_size=100M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
     && echo "opcache.jit=tracing" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-# Production PHP limits for marketplace forms, photo uploads and Laravel runtime.
+# Production PHP limits for marketplace forms, photo/video uploads and Laravel runtime.
+# Keep PHP request limits above Laravel's 51200 KB video validation cap so Laravel returns controlled validation errors.
 RUN { \
         echo "memory_limit=256M"; \
-        echo "upload_max_filesize=10M"; \
-        echo "post_max_size=25M"; \
+        echo "upload_max_filesize=64M"; \
+        echo "post_max_size=64M"; \
         echo "max_file_uploads=12"; \
         echo "max_execution_time=60"; \
         echo "max_input_time=60"; \


### PR DESCRIPTION
## Summary
- Raises backend PHP `upload_max_filesize` and `post_max_size` from 10M/25M to 64M.
- Keeps the existing Laravel `video_file` validation at 51200 KB, making PHP no longer reject valid Laravel-sized videos first.
- This is a partial #200 runtime-alignment fix; nginx `client_max_body_size` still needs to be raised to at least 64m through a safe nginx/server-gate patch.

## Risk
- Medium: upload request cap increases on PHP-FPM, so this should rely on existing auth, media validation, file count limits, image resizing, and infrastructure rate limits.
- No controller rewrite, payment, auth, routing, database, or UI changes.

## Gates
Expected on PR:
- Production checks
- Docker backend build
- Compose validation
- Static safety scans where available

Manual/server follow-up before closing #200:
- Update nginx `client_max_body_size` from 25m to 64m.
- Run `nginx -t` and `bash scripts/server-operator.sh verify_quick` through the server gate.

## Rollback
- Revert this PR to restore previous PHP upload/request limits.

Refs #200