### PR TITLE
fix(media): raise PHP upload runtime cap

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -76,11 +76,12 @@ RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.
     && echo "opcache.jit_buffer_size=100M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
     && echo "opcache.jit=tracing" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-# Production PHP limits for marketplace forms, photo uploads and Laravel runtime.
+# Production PHP limits for marketplace forms, photo/video uploads and Laravel runtime.
+# Keep PHP request limits above Laravel's 51200 KB video validation cap.
 RUN { \
         echo "memory_limit=256M"; \
-        echo "upload_max_filesize=10M"; \
-        echo "post_max_size=25M"; \
+        echo "upload_max_filesize=64M"; \
+        echo "post_max_size=64M"; \
         echo "max_file_uploads=12"; \
         echo "max_execution_time=60"; \
         echo "max_input_time=60"; \


### PR DESCRIPTION
## Summary
- Raises backend PHP `upload_max_filesize` and `post_max_size` to 64M.
- Keeps existing Laravel video validation at 51200 KB.
- Pairs with the guarded server operation `align_media_caps`, which aligns nginx `client_max_body_size` to 64m and runs live validation.

## Risk
- Medium: raises PHP upload/request cap, but only for authenticated marketplace upload flows governed by existing Laravel validation and media controls.
- No controller, payment, auth, route, database, or UI changes.

## Gates
Expected:
- Production checks
- Backend Docker build
- Compose validation
- Server gate: `/server align-media-caps MERCASTO` on #200

## Rollback
- Revert this PR to restore previous PHP upload/request limits.

Refs #200