### PR TITLE
fix(media): align nginx upload cap with PHP runtime

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -32,8 +32,8 @@ server {
     # Hide nginx version from attack surface
     server_tokens off;
 
-    # Match Laravel image-upload limits and leave room for multipart form data.
-    client_max_body_size 25m;
+    # Match PHP upload runtime limits and leave room for Laravel video validation.
+    client_max_body_size 64m;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
## Summary
- Raises nginx `client_max_body_size` from 25m to 64m.
- Aligns nginx with the PHP upload runtime cap already merged in #206.
- Keeps Laravel video validation as the controlled application validation layer.

## Risk
- Medium: increases accepted request body size at nginx.
- Change is limited to one nginx directive and does not touch auth, payments, Laravel controllers, database, UI, or routing.

## Smoke
- Expected CI: production checks and compose validation.
- Required live gate before closing #200: nginx config validation, frontend restart, public smoke, and `verify:quick` on the production server.

## Rollback
- Revert this PR to restore `client_max_body_size 25m`.

Refs #200