### PR TITLE
ci: trigger current main verification path

### DIFF
--- a/backend/.ci-current-main-gate
+++ b/backend/.ci-current-main-gate
@@ -1,0 +1,2 @@
+Current-main gate verification marker.
+This branch exists only to trigger PR and post-merge verification workflows.


### PR DESCRIPTION
## Summary
- Opens a verification-only PR from current main.
- Adds a backend CI marker so existing PR gates run.
- No runtime code or configuration changes are intended.

## Risk
- Low. This PR is verification-only.

## Smoke
- Expected PR checks: Production checks, PR Quality Gate, backend gates.
- After merge, Production checks should trigger the read-only Autonomous Server Live Gate.

## Rollback
- Close or revert this PR marker.
