### PR TITLE
Sprint 7.1: add category-aware backend filters on current main

### DIFF
--- a/backend/app/Http/Controllers/Api/AdIndexController.php
+++ b/backend/app/Http/Controllers/Api/AdIndexController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ad;
+use App\Support\AdQueryFilters;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class AdIndexController extends Controller
+{
+    /**
+     * Public ad listing endpoint with global and category-specific filters.
+     */
+    public function index(Request $request)
+    {
+        $page = (int) $request->query('page', 1);
+        if ($page > 100) {
+            return response()->json(['message' => 'Límite de paginación excedido para proteger la base de datos.'], 400);
+        }
+
+        $query = Ad::with('user:id,name,role,avatar_url,is_verified,created_at');
+
+        if ($request->filled('lat') && $request->filled('lng') && $request->filled('radius')) {
+            $lat = (float) $request->lat;
+            $lng = (float) $request->lng;
+            $radius = (int) $request->radius;
+
+            $haversine = "( 6371 * acos( greatest(-1.0, least(1.0, cos( radians(?) ) * cos( radians( latitude ) ) * cos( radians( longitude ) - radians(?) ) + sin( radians(?) ) * sin( radians( latitude ) ) ) ) ) )";
+
+            $query->selectRaw("*, {$haversine} AS distance", [$lat, $lng, $lat])
+                ->where('status', 'active')
+                ->whereNotNull('latitude')
+                ->whereRaw("{$haversine} < ?", [$lat, $lng, $lat, $radius])
+                ->orderBy('distance');
+        } else {
+            $query->where('ads.status', 'active');
+        }
+
+        if ($request->filled('user_id')) {
+            $query->where('user_id', $request->user_id);
+        }
+
+        if ($request->filled('category')) {
+            $query->where('category', $request->category);
+        }
+
+        if ($request->filled('search')) {
+            $search = (string) $request->search;
+            $apiKey = config('services.gemini.api_key', env('GEMINI_API_KEY'));
+            $vectorSearchSuccess = false;
+
+            if ($apiKey) {
+                $response = Http::post("https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key={$apiKey}", [
+                    'model' => 'models/text-embedding-004',
+                    'content' => ['parts' => [['text' => $search]]],
+                ]);
+
+                if ($response->successful() && $embedding = $response->json('embedding.values')) {
+                    $embeddingString = '[' . implode(',', $embedding) . ']';
+                    $query->whereNotNull('embedding')->orderByRaw('embedding <=> ?', [$embeddingString]);
+                    $vectorSearchSuccess = true;
+                }
+            }
+
+            if (! $vectorSearchSuccess) {
+                $query->where(function ($q) use ($search): void {
+                    $q->where('title', 'like', "%{$search}%")
+                        ->orWhere('description', 'like', "%{$search}%");
+                });
+            }
+        }
+
+        if ($request->filled('location')) {
+            $locationParts = collect(explode(',', (string) $request->location))
+                ->map(fn ($part) => trim($part))
+                ->filter()
+                ->unique()
+                ->values();
+
+            $query->where(function ($q) use ($locationParts, $request): void {
+                $q->where('location', 'like', '%' . $request->location . '%');
+                foreach ($locationParts as $part) {
+                    $q->orWhere('location', 'like', '%' . $part . '%');
+                }
+            });
+        }
+
+        if ($request->filled('state')) {
+            $query->where('state', $request->state);
+        }
+
+        if ($request->filled('condition')) {
+            $conditions = is_array($request->condition) ? $request->condition : explode(',', (string) $request->condition);
+            $query->whereIn('condition', $conditions);
+        }
+
+        AdQueryFilters::apply($query, $request);
+
+        $sort = $request->query('sort', 'latest');
+        if ($sort === 'price_asc') {
+            $query->orderBy('price', 'asc');
+        } elseif ($sort === 'price_desc') {
+            $query->orderBy('price', 'desc');
+        } elseif ($sort === 'popular') {
+            $query->orderBy('views', 'desc');
+        } elseif ($sort === 'latest' && ! $request->filled('radius')) {
+            $query->latest();
+        }
+
+        $hasFilters = $request->anyFilled([
+            'lat',
+            'lng',
+            'radius',
+            'user_id',
+            'category',
+            'search',
+            'location',
+            'state',
+            'min_price',
+            'max_price',
+            'condition',
+            'sort',
+        ]) || AdQueryFilters::hasAdvancedFilters($request);
+
+        if (! $hasFilters && $page <= 10) {
+            $cacheKey = "ads_index_page_{$page}";
+
+            return response()->json(Cache::remember($cacheKey, 60, function () use ($query) {
+                return $query->paginate(16)->toArray();
+            }));
+        }
+
+        return response()->json($query->paginate(16));
+    }
+}

--- a/backend/app/Support/AdQueryFilters.php
+++ b/backend/app/Support/AdQueryFilters.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class AdQueryFilters
+{
+    private const MAX_STRING_LENGTH = 80;
+
+    public static function apply(Builder $query, Request $request): void
+    {
+        self::applyGlobalFilters($query, $request);
+        self::applyCategoryFilters($query, $request);
+    }
+
+    public static function hasAdvancedFilters(Request $request): bool
+    {
+        return $request->anyFilled([
+            'price_min',
+            'price_max',
+            'published_days',
+            'verified_only',
+        ]) || $request->filled('filters');
+    }
+
+    private static function applyGlobalFilters(Builder $query, Request $request): void
+    {
+        $priceMin = self::numeric($request->query('price_min', $request->query('min_price')));
+        if ($priceMin !== null) {
+            $query->where('price', '>=', $priceMin);
+        }
+
+        $priceMax = self::numeric($request->query('price_max', $request->query('max_price')));
+        if ($priceMax !== null) {
+            $query->where('price', '<=', $priceMax);
+        }
+
+        $publishedDays = self::positiveInt($request->query('published_days'));
+        if ($publishedDays !== null) {
+            $publishedDays = min($publishedDays, (int) config('category_attributes.global_filters.published_days.max', 365));
+            $query->where('ads.created_at', '>=', now()->subDays($publishedDays));
+        }
+
+        if ($request->boolean('verified_only')) {
+            $query->whereHas('user', static function (Builder $userQuery): void {
+                $userQuery->where('is_verified', true);
+            });
+        }
+    }
+
+    private static function applyCategoryFilters(Builder $query, Request $request): void
+    {
+        $filters = $request->query('filters');
+
+        if (! is_array($filters) || $filters === []) {
+            return;
+        }
+
+        $allowed = self::allowedFilterMap((string) $request->query('category', ''));
+
+        foreach ($filters as $rawKey => $rawValue) {
+            if (! is_string($rawKey)) {
+                continue;
+            }
+
+            $normalized = self::normalizeKey($rawKey);
+            $field = $allowed[$normalized] ?? null;
+
+            if (! is_array($field)) {
+                continue;
+            }
+
+            $attributeKey = (string) $field['key'];
+            $filterType = (string) Arr::get($field, 'filter', 'exact');
+            $valueType = (string) Arr::get($field, 'type', 'string');
+
+            if ($filterType === 'range' && is_array($rawValue)) {
+                self::applyRangeAttributeFilter($query, $attributeKey, $rawValue, $valueType);
+                continue;
+            }
+
+            self::applyExactAttributeFilter($query, $attributeKey, $rawValue, $valueType);
+        }
+    }
+
+    private static function applyRangeAttributeFilter(Builder $query, string $attributeKey, array $value, string $valueType): void
+    {
+        $min = self::numeric($value['min'] ?? null);
+        $max = self::numeric($value['max'] ?? null);
+
+        if ($min !== null) {
+            $query->where("attributes->{$attributeKey}", '>=', $valueType === 'integer' ? (int) $min : $min);
+        }
+
+        if ($max !== null) {
+            $query->where("attributes->{$attributeKey}", '<=', $valueType === 'integer' ? (int) $max : $max);
+        }
+    }
+
+    private static function applyExactAttributeFilter(Builder $query, string $attributeKey, mixed $rawValue, string $valueType): void
+    {
+        if (is_array($rawValue)) {
+            $values = collect($rawValue)
+                ->map(fn (mixed $item): mixed => self::sanitizeValue($item, $valueType))
+                ->filter(static fn (mixed $item): bool => $item !== null && $item !== '')
+                ->unique()
+                ->take(20)
+                ->values()
+                ->all();
+
+            if ($values !== []) {
+                $query->whereIn("attributes->{$attributeKey}", $values);
+            }
+
+            return;
+        }
+
+        $value = self::sanitizeValue($rawValue, $valueType);
+
+        if ($value !== null && $value !== '') {
+            $query->where("attributes->{$attributeKey}", $value);
+        }
+    }
+
+    private static function allowedFilterMap(string $category): array
+    {
+        $verticals = (array) config('category_attributes.verticals', []);
+        $map = [];
+
+        foreach ($verticals as $vertical) {
+            $categorySlugs = (array) Arr::get($vertical, 'category_slugs', []);
+
+            if ($category !== '' && ! in_array($category, $categorySlugs, true)) {
+                continue;
+            }
+
+            foreach ((array) Arr::get($vertical, 'attributes', []) as $key => $definition) {
+                if (! is_array($definition)) {
+                    continue;
+                }
+
+                $field = $definition;
+                $field['key'] = $key;
+                $map[self::normalizeKey((string) $key)] = $field;
+
+                foreach ((array) Arr::get($definition, 'aliases', []) as $alias) {
+                    $map[self::normalizeKey((string) $alias)] = $field;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    private static function sanitizeValue(mixed $value, string $type): mixed
+    {
+        if ($type === 'integer') {
+            return self::positiveInt($value);
+        }
+
+        if ($type === 'number') {
+            return self::numeric($value);
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        return Str::of((string) $value)->trim()->limit(self::MAX_STRING_LENGTH, '')->toString();
+    }
+
+    private static function numeric(mixed $value): float|int|null
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return $value + 0;
+    }
+
+    private static function positiveInt(mixed $value): ?int
+    {
+        $number = self::numeric($value);
+
+        if ($number === null) {
+            return null;
+        }
+
+        $int = (int) $number;
+
+        return $int > 0 ? $int : null;
+    }
+
+    private static function normalizeKey(string $key): string
+    {
+        return Str::of($key)
+            ->lower()
+            ->replace(['á', 'é', 'í', 'ó', 'ú', 'ñ'], ['a', 'e', 'i', 'o', 'u', 'n'])
+            ->replaceMatches('/[^a-z0-9_]+/', '_')
+            ->trim('_')
+            ->toString();
+    }
+}

--- a/backend/config/category_attributes.php
+++ b/backend/config/category_attributes.php
@@ -1,0 +1,93 @@
+<?php
+
+return [
+    'version' => 1,
+
+    'verticals' => [
+        'autos' => [
+            'category_slugs' => [
+                'coches-y-motor/coches',
+                'coches-y-motor/motos',
+                'coches-y-motor/refacciones',
+            ],
+            'attributes' => [
+                'marca' => ['type' => 'string', 'filter' => 'exact'],
+                'modelo' => ['type' => 'string', 'filter' => 'exact'],
+                'año' => ['type' => 'integer', 'filter' => 'range', 'aliases' => ['year']],
+                'kilometraje' => ['type' => 'integer', 'filter' => 'range', 'aliases' => ['km']],
+                'transmision' => ['type' => 'string', 'filter' => 'exact'],
+                'combustible' => ['type' => 'string', 'filter' => 'exact'],
+            ],
+        ],
+
+        'inmuebles' => [
+            'category_slugs' => [
+                'inmuebles/casas-en-venta',
+                'inmuebles/casas-en-renta',
+                'inmuebles/departamentos',
+                'inmuebles/terrenos',
+                'inmuebles/locales-comerciales',
+                'inmuebles/oficinas',
+                'inmuebles/bodegas',
+                'inmuebles/renta-vacacional',
+            ],
+            'attributes' => [
+                'metros_cuadrados' => ['type' => 'integer', 'filter' => 'range', 'aliases' => ['m2']],
+                'habitaciones' => ['type' => 'integer', 'filter' => 'range'],
+                'baños' => ['type' => 'integer', 'filter' => 'range', 'aliases' => ['banos']],
+                'tipo' => ['type' => 'string', 'filter' => 'exact'],
+                'operacion' => ['type' => 'string', 'filter' => 'exact'],
+            ],
+        ],
+
+        'empleos' => [
+            'category_slugs' => [
+                'empleos/ventas',
+                'empleos/chofer',
+                'empleos/construccion',
+                'empleos/administracion',
+                'empleos/atencion-al-cliente',
+                'empleos/tecnologia',
+                'empleos/hoteleria',
+                'empleos/medio-tiempo',
+            ],
+            'attributes' => [
+                'salario' => ['type' => 'integer', 'filter' => 'range'],
+                'tipo_empleo' => ['type' => 'string', 'filter' => 'exact'],
+                'modalidad' => ['type' => 'string', 'filter' => 'exact'],
+                'experiencia' => ['type' => 'string', 'filter' => 'exact'],
+            ],
+        ],
+
+        'electronica' => [
+            'category_slugs' => [
+                'electronica/laptops',
+                'electronica/tablets',
+                'electronica/tv-y-video',
+                'electronica/audio',
+                'electronica/camaras',
+                'electronica/drones',
+                'electronica/accesorios',
+                'moviles-y-telefonia/iphone',
+                'moviles-y-telefonia/android',
+                'moviles-y-telefonia/smartwatch',
+                'moviles-y-telefonia/accesorios',
+                'moviles-y-telefonia/tablets',
+                'moviles-y-telefonia/repuestos',
+            ],
+            'attributes' => [
+                'marca' => ['type' => 'string', 'filter' => 'exact'],
+                'modelo' => ['type' => 'string', 'filter' => 'exact'],
+                'condicion' => ['type' => 'string', 'filter' => 'exact'],
+                'almacenamiento' => ['type' => 'string', 'filter' => 'exact'],
+            ],
+        ],
+    ],
+
+    'global_filters' => [
+        'price_min' => ['column' => 'price', 'operator' => '>=', 'type' => 'number', 'aliases' => ['min_price']],
+        'price_max' => ['column' => 'price', 'operator' => '<=', 'type' => 'number', 'aliases' => ['max_price']],
+        'published_days' => ['column' => 'created_at', 'type' => 'days_back', 'max' => 365],
+        'verified_only' => ['relation' => 'user', 'column' => 'is_verified', 'type' => 'boolean'],
+    ],
+];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AdController;
+use App\Http\Controllers\Api\AdIndexController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ProfileController;
 use App\Http\Controllers\Api\BusinessProfileController;
@@ -20,7 +21,7 @@ use App\Http\Controllers\Api\NotificationController;
 
 // Public routes
 Route::middleware('throttle:search')->get('/search/suggestions', [SearchController::class, 'suggestions']);
-Route::middleware('throttle:search')->get('/ads', [AdController::class, 'index']);
+Route::middleware('throttle:search')->get('/ads', [AdIndexController::class, 'index']);
 Route::middleware('throttle:api')->get('/ads/{id}', [AdController::class, 'show'])->whereNumber('id'); // Добавлен маршрут для прямых ссылок (SEO/Deep Links)
 
 // Защита от CPU DDoS: генерация PDF очень ресурсоемкая, ставим лимит 10 в минуту
@@ -119,8 +120,7 @@ Route::middleware('throttle:auth')->group(function () {
     Route::post('/reset-password', [AuthController::class, 'resetPassword']);
 });
 
-// Returns which OAuth providers are actually configured (credentials present in env)
-// IMPORTANT: must be defined BEFORE the {provider} wildcard routes
+// OAuth provider availability endpoint must be defined BEFORE provider wildcard routes.
 Route::middleware('throttle:api')->get('/auth/providers', [AuthController::class, 'getProviders']);
 
 // OAuth wildcard routes (must come AFTER static /auth/providers)

--- a/scripts/category-filter-smoke.sh
+++ b/scripts/category-filter-smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://mercasto.com}"
+TMP_FILE="${TMPDIR:-/tmp}/mercasto-category-filter-smoke.json"
+
+check_url() {
+  local label="$1"
+  local path="$2"
+  local url="${BASE_URL}${path}"
+  local code
+
+  code="$(curl -k -sS -o "$TMP_FILE" -w '%{http_code}' "$url" || true)"
+  echo "$label -> $code"
+
+  if [ "$code" != "200" ]; then
+    echo "FAIL: $label returned HTTP $code" >&2
+    head -c 1000 "$TMP_FILE" 2>/dev/null || true
+    echo >&2
+    exit 1
+  fi
+
+  python3 -m json.tool "$TMP_FILE" >/dev/null
+}
+
+echo "== Category filter smoke =="
+
+check_url "price range" "/api/ads?page=1&price_min=0&price_max=999999999"
+check_url "published days" "/api/ads?page=1&published_days=365"
+check_url "verified only" "/api/ads?page=1&verified_only=1"
+check_url "autos exact attribute" "/api/ads?page=1&category=coches-y-motor/coches&filters%5Bmarca%5D=Toyota"
+check_url "autos range attribute" "/api/ads?page=1&category=coches-y-motor/coches&filters%5Byear%5D%5Bmin%5D=2015&filters%5Byear%5D%5Bmax%5D=2026"
+check_url "inmuebles range attribute" "/api/ads?page=1&category=inmuebles/departamentos&filters%5Bm2%5D%5Bmin%5D=20&filters%5Bm2%5D%5Bmax%5D=500"
+check_url "empleos salary attribute" "/api/ads?page=1&category=empleos/ventas&filters%5Bsalario%5D%5Bmin%5D=0"
+
+echo "category filter smoke OK"


### PR DESCRIPTION
## Summary
Rebuilds the category-aware backend filters branch on top of the current `main` after business-profile changes landed.

## Changes
- Adds category attribute filter config for Autos, Inmuebles, Empleo, Electrónica and Móviles.
- Adds allowlisted `AdQueryFilters` for global filters and category attributes.
- Adds `AdIndexController` for public `/api/ads` listing filters while leaving the large existing `AdController` intact for detail/edit/admin flows.
- Routes public `/api/ads` through the new index controller.
- Adds a standalone `scripts/category-filter-smoke.sh` smoke script.

## Risk
Medium backend risk because public `/api/ads` uses a new listing controller. Risk is reduced by allowlisted filters, unchanged detail/edit/admin routes, no migrations, no payments changes, and no external secrets.

## Smoke
Expected checks:
- PHP syntax for the new controller and filter helper.
- Existing production smoke.
- Standalone `bash scripts/category-filter-smoke.sh` against production or staging.
- Existing full gate before merge.

## Rollback
Revert this PR to return `/api/ads` to `AdController@index` and remove the new helper/config/smoke script. No database rollback is required.

Closes #219.