### PR TITLE
feat: activate AI description fallback route

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AdController;
+use App\Http\Controllers\Api\AiDescriptionController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ProfileController;
 use App\Http\Controllers\Api\BusinessProfileController;
@@ -119,8 +120,7 @@ Route::middleware('throttle:auth')->group(function () {
     Route::post('/reset-password', [AuthController::class, 'resetPassword']);
 });
 
-// Returns which OAuth providers are actually configured (credentials present in env)
-// IMPORTANT: must be defined BEFORE the {provider} wildcard routes
+// OAuth provider availability endpoint must be defined BEFORE provider wildcard routes.
 Route::middleware('throttle:api')->get('/auth/providers', [AuthController::class, 'getProviders']);
 
 // OAuth wildcard routes (must come AFTER static /auth/providers)
@@ -151,7 +151,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::middleware('throttle:ads')->post('/ads', [AdController::class, 'store']);
     // Защита ИИ от спама и истощения лимитов API (максимум 5 генераций в минуту на пользователя)
     Route::middleware('throttle:5,1')->group(function () {
-        Route::post('/ads/generate-description', [AdController::class, 'generateDescription']); // DeepSeek/Qwen AI
+        Route::post('/ads/generate-description', AiDescriptionController::class); // DeepSeek primary + Ollama/Qwen fallback
     });
     Route::post('/categories', [CategoryController::class, 'store']); // Создание категории (только для админов)
     Route::put('/categories/{id}', [CategoryController::class, 'update']); // Редактирование категории


### PR DESCRIPTION
## Summary
Activates the merged AI description fallback controller for `/api/ads/generate-description`.

## Changes
- Imports `AiDescriptionController` in `backend/routes/api.php`.
- Routes the authenticated AI description endpoint to the invokable controller.
- Keeps the existing throttle wrapper unchanged.

## Risk
Low-to-medium backend routing risk because this changes one active authenticated endpoint. Rollback is one-line: point the route back to `AdController@generateDescription`.

## Smoke
Expected checks:
- PHP route syntax via backend gates.
- Existing production checks.
- Authenticated live smoke after merge/deploy.

## Rollback
Revert this PR or restore `/api/ads/generate-description` to `AdController@generateDescription`.