### PR TITLE
feat: add OG share pages for ads

### DIFF
--- a/backend/app/Http/Controllers/ShareAdController.php
+++ b/backend/app/Http/Controllers/ShareAdController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ad;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+
+class ShareAdController extends Controller
+{
+    public function __invoke(int $id): Response
+    {
+        $ad = Ad::query()
+            ->where('status', 'active')
+            ->findOrFail($id);
+
+        $title = Str::limit($ad->title ?: 'Anuncio en Mercasto', 80, '');
+        $description = Str::limit(trim(strip_tags((string) $ad->description)) ?: 'Mira este anuncio en Mercasto, marketplace de clasificados para México.', 180, '');
+        $canonicalUrl = url('/ads/' . $ad->id);
+        $shareUrl = url('/share/ads/' . $ad->id);
+        $imageUrl = $ad->image_url ? url($ad->image_url) : url('/icon-512x512.png');
+        $price = $ad->price ? '$' . number_format((float) $ad->price, 0, '.', ',') . ' MXN' : 'Precio en Mercasto';
+        $pageTitle = e($title . ' | ' . $price . ' | Mercasto');
+        $escapedDescription = e($description);
+        $escapedImage = e($imageUrl);
+        $escapedCanonical = e($canonicalUrl);
+        $escapedShare = e($shareUrl);
+
+        $html = <<<HTML
+<!doctype html>
+<html lang="es-MX">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{$pageTitle}</title>
+  <meta name="description" content="{$escapedDescription}">
+  <link rel="canonical" href="{$escapedCanonical}">
+  <meta property="og:type" content="product">
+  <meta property="og:site_name" content="Mercasto">
+  <meta property="og:title" content="{$pageTitle}">
+  <meta property="og:description" content="{$escapedDescription}">
+  <meta property="og:url" content="{$escapedShare}">
+  <meta property="og:image" content="{$escapedImage}">
+  <meta property="og:locale" content="es_MX">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{$pageTitle}">
+  <meta name="twitter:description" content="{$escapedDescription}">
+  <meta name="twitter:image" content="{$escapedImage}">
+  <meta http-equiv="refresh" content="0; url={$escapedCanonical}">
+  <script>location.replace({$this->json($canonicalUrl)});</script>
+</head>
+<body>
+  <main style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;padding:32px;max-width:720px;margin:auto">
+    <h1>{$pageTitle}</h1>
+    <p>{$escapedDescription}</p>
+    <p><a href="{$escapedCanonical}">Ver anuncio en Mercasto</a></p>
+  </main>
+</body>
+</html>
+HTML;
+
+        return response($html, 200)->header('Content-Type', 'text/html; charset=UTF-8');
+    }
+
+    private function json(string $value): string
+    {
+        return json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+    }
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ShareAdController;
+
+Route::get('/share/ads/{id}', ShareAdController::class)->whereNumber('id');
 
 Route::get('/', function () {
     return view('welcome');

--- a/default.conf
+++ b/default.conf
@@ -125,8 +125,8 @@ server {
         return 200 "ok\n";
     }
 
-    # 3. Route API requests to Laravel
-    location ~ ^/(api|webhooks|broadcasting|sanctum|graphql) {
+    # 3. Route API and server-rendered share pages to Laravel
+    location ~ ^/(api|webhooks|broadcasting|sanctum|graphql|share) {
         root /var/www/public;
         try_files $uri $uri/ /index.php?$query_string;
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;


### PR DESCRIPTION
## Summary
Add server-rendered share pages for listings so messengers and social crawlers receive ad-specific Open Graph and Twitter metadata.

## Risk
Medium-low. Adds a dedicated backend share route and routes `/share/*` through Laravel in nginx. Existing SPA `/ads/{id}` flow is unchanged.

## Smoke
Run backend syntax/tests, nginx config check, production checks, and verify `/share/ads/1` returns HTML with `og:title`, `og:description`, and `og:image`.

## Rollback
Revert this PR to remove the share controller, route, and nginx share routing.