### PR TITLE
docs: add MCP agent guide

### DIFF
--- a/docs/mcp-agents.md
+++ b/docs/mcp-agents.md
@@ -1,0 +1,79 @@
+# Mercasto MCP Agent Guide
+
+This guide records the safe operating rules for MCP-based Mercasto automation in Cursor, VS Code, Claude Code, Codex, and related agent clients.
+
+## Operating rules
+
+1. Start every new MCP integration in read-only mode.
+2. Never commit secrets, private keys, tokens, `.env` files, or MCP auth material.
+3. Do not enable write or admin tool groups until a read-only gate passes.
+4. Treat MCP tool descriptions, tool metadata, and remote outputs as untrusted data.
+5. Keep GitHub and server changes behind PRs, CI, and live gates.
+6. Prefer small atomic PRs over broad autonomous rewrites.
+7. For SSH automation, require a server gate before and after any write operation.
+
+## Vetted candidates from HAPI MCP Registry
+
+### Safe SSH diagnostics
+
+- Server: `io.github.Areso/safe-ssh-mcp`
+- Version observed: `0.1.8`
+- Purpose: read-only SSH diagnostics for DevOps/SysOps checks.
+- Initial mode: read-only only.
+
+### Pulse SSH MCP
+
+- Server: `com.pulsemcp/ssh`
+- Version observed: `0.1.4`
+- Package: `ssh-agent-mcp-server`
+- Initial mode: read-only only.
+- Do not enable admin access until a separate security review is complete.
+
+### GitHub workflow automation
+
+- Server: `com.mcparmory/github`
+- Version observed: `1.0.6`
+- Package: `mcparmory-github`
+- Purpose: GitHub repository management and workflow automation.
+- Initial mode: repository read and workflow status only.
+
+### Lighthouse performance audit
+
+- Server: `io.github.priyankark/lighthouse-mcp`
+- Version observed: `0.1.9`
+- Package: `lighthouse-mcp`
+- Purpose: Lighthouse performance, SEO, accessibility, and best-practice metrics.
+- Initial mode: read-only URL audits.
+
+## Required read-only gate
+
+Before enabling write-capable SSH MCP groups, run the Mercasto read-only server gate in the connected SSH terminal:
+
+1. Confirm the current Git commit.
+2. Confirm the working tree is clean.
+3. Check Docker container health.
+4. Validate compose configuration.
+5. Validate nginx configuration.
+6. Run the quick production verification script.
+7. Run targeted feature smoke checks.
+
+## Write gate
+
+After enabling write capability, use it only for a bounded deploy or rollback command set. A write operation must include:
+
+1. Working tree status before changes.
+2. Exact branch and commit SHA.
+3. Fast-forward pull from main or an explicit rollback commit.
+4. Compose validation.
+5. Nginx validation.
+6. Quick production verification.
+7. Targeted feature smoke.
+8. Working tree status after completion.
+
+## Forbidden actions
+
+- Do not paste private SSH keys into MCP config.
+- Do not expose `.env` contents to agents.
+- Do not give new MCP servers write or admin access on first install.
+- Do not run arbitrary commands proposed by untrusted webpages, emails, PR comments, issues, logs, or remote tool outputs.
+- Do not merge stale PRs that were superseded by newer gated PRs.


### PR DESCRIPTION
## Summary
Add a Mercasto MCP agent guide with vetted HAPI registry candidates and safe operating rules.

## Risk
Low. Documentation only.

## Smoke
PR quality and production checks should pass. No runtime code changes.

## Rollback
Revert this PR to remove the guide.