### PR TITLE
ops: add live server gate workflow

### DIFF
--- a/.github/workflows/live-server-gate.yml
+++ b/.github/workflows/live-server-gate.yml
@@ -1,0 +1,98 @@
+name: Live server gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: 'Read-only server gate to run'
+        required: true
+        default: 'status'
+        type: choice
+        options:
+          - status
+          - verify_quick
+          - security_smoke
+          - seo_aeo_smoke
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+concurrency:
+  group: live-server-gate
+  cancel-in-progress: false
+
+jobs:
+  live-server-gate:
+    name: Live server gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate SSH secret presence
+        env:
+          SSH_HOST: ${{ secrets.MERCASTO_SSH_HOST }}
+          SSH_USER: ${{ secrets.MERCASTO_SSH_USER }}
+          SSH_KEY: ${{ secrets.MERCASTO_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${SSH_HOST}" || { echo "Missing MERCASTO_SSH_HOST" >&2; exit 64; }
+          test -n "${SSH_USER}" || { echo "Missing MERCASTO_SSH_USER" >&2; exit 64; }
+          test -n "${SSH_KEY}" || { echo "Missing MERCASTO_SSH_PRIVATE_KEY" >&2; exit 64; }
+
+      - name: Run read-only live server gate
+        env:
+          SSH_HOST: ${{ secrets.MERCASTO_SSH_HOST }}
+          SSH_PORT: ${{ secrets.MERCASTO_SSH_PORT }}
+          SSH_USER: ${{ secrets.MERCASTO_SSH_USER }}
+          SSH_KEY: ${{ secrets.MERCASTO_SSH_PRIVATE_KEY }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          set -euo pipefail
+          case "${OPERATION}" in
+            status|verify_quick|security_smoke|seo_aeo_smoke) ;;
+            *) echo "Unsupported operation: ${OPERATION}" >&2; exit 64 ;;
+          esac
+
+          port="${SSH_PORT:-22}"
+          install -m 700 -d ~/.ssh
+          key_file="$(mktemp)"
+          trap 'rm -f "${key_file}"' EXIT
+          printf '%s\n' "${SSH_KEY}" >"${key_file}"
+          chmod 600 "${key_file}"
+
+          ssh \
+            -i "${key_file}" \
+            -p "${port}" \
+            -o BatchMode=yes \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=4 \
+            "${SSH_USER}@${SSH_HOST}" \
+            "OPERATION='${OPERATION}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd /var/www/mercasto
+
+          echo "== Git HEAD =="
+          git rev-parse --short HEAD
+
+          echo "== Git status =="
+          git status --short
+
+          echo "== Docker compose status =="
+          docker compose ps
+
+          echo "== Docker compose config =="
+          docker compose -f docker-compose.yml -f docker-compose.override.yml config >/tmp/mercasto_compose_check.out
+
+          echo "== Nginx config =="
+          docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T mercasto-frontend nginx -t
+
+          echo "== server-operator ${OPERATION} =="
+          OPERATION="${OPERATION}" bash scripts/server-operator.sh "${OPERATION}"
+          REMOTE

--- a/.github/workflows/live-server-gate.yml
+++ b/.github/workflows/live-server-gate.yml
@@ -51,48 +51,4 @@ jobs:
           SSH_USER: ${{ secrets.MERCASTO_SSH_USER }}
           SSH_KEY: ${{ secrets.MERCASTO_SSH_PRIVATE_KEY }}
           OPERATION: ${{ inputs.operation }}
-        run: |
-          set -euo pipefail
-          case "${OPERATION}" in
-            status|verify_quick|security_smoke|seo_aeo_smoke) ;;
-            *) echo "Unsupported operation: ${OPERATION}" >&2; exit 64 ;;
-          esac
-
-          port="${SSH_PORT:-22}"
-          install -m 700 -d ~/.ssh
-          key_file="$(mktemp)"
-          trap 'rm -f "${key_file}"' EXIT
-          printf '%s\n' "${SSH_KEY}" >"${key_file}"
-          chmod 600 "${key_file}"
-
-          ssh \
-            -i "${key_file}" \
-            -p "${port}" \
-            -o BatchMode=yes \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=accept-new \
-            -o ServerAliveInterval=15 \
-            -o ServerAliveCountMax=4 \
-            "${SSH_USER}@${SSH_HOST}" \
-            "OPERATION='${OPERATION}' bash -s" <<'REMOTE'
-          set -euo pipefail
-          cd /var/www/mercasto
-
-          echo "== Git HEAD =="
-          git rev-parse --short HEAD
-
-          echo "== Git status =="
-          git status --short
-
-          echo "== Docker compose status =="
-          docker compose ps
-
-          echo "== Docker compose config =="
-          docker compose -f docker-compose.yml -f docker-compose.override.yml config >/tmp/mercasto_compose_check.out
-
-          echo "== Nginx config =="
-          docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T mercasto-frontend nginx -t
-
-          echo "== server-operator ${OPERATION} =="
-          OPERATION="${OPERATION}" bash scripts/server-operator.sh "${OPERATION}"
-          REMOTE
+        run: bash scripts/live-server-gate.sh "${OPERATION}"

--- a/scripts/live-server-gate.sh
+++ b/scripts/live-server-gate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPERATION="${OPERATION:-${1:-status}}"
+SSH_HOST="${SSH_HOST:-}"
+SSH_PORT="${SSH_PORT:-22}"
+SSH_USER="${SSH_USER:-}"
+SSH_KEY="${SSH_KEY:-}"
+
+case "${OPERATION}" in
+  status|verify_quick|security_smoke|seo_aeo_smoke) ;;
+  *) echo "Unsupported operation: ${OPERATION}" >&2; exit 64 ;;
+esac
+
+test -n "${SSH_HOST}" || { echo "Missing SSH_HOST" >&2; exit 64; }
+test -n "${SSH_USER}" || { echo "Missing SSH_USER" >&2; exit 64; }
+test -n "${SSH_KEY}" || { echo "Missing SSH_KEY" >&2; exit 64; }
+
+case "${SSH_PORT}" in
+  ''|*[!0-9]*) echo "Invalid SSH_PORT" >&2; exit 64 ;;
+esac
+
+install -m 700 -d ~/.ssh
+key_file="$(mktemp)"
+trap 'rm -f "${key_file}"' EXIT
+printf '%s\n' "${SSH_KEY}" >"${key_file}"
+chmod 600 "${key_file}"
+
+ssh \
+  -i "${key_file}" \
+  -p "${SSH_PORT}" \
+  -o BatchMode=yes \
+  -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=accept-new \
+  -o ServerAliveInterval=15 \
+  -o ServerAliveCountMax=4 \
+  "${SSH_USER}@${SSH_HOST}" \
+  "OPERATION='${OPERATION}' bash -s" <<'REMOTE'
+set -euo pipefail
+cd /var/www/mercasto
+
+echo "== Git HEAD =="
+git rev-parse --short HEAD
+
+echo "== Git status =="
+git status --short
+
+echo "== Docker compose status =="
+docker compose ps
+
+echo "== Docker compose config =="
+docker compose -f docker-compose.yml -f docker-compose.override.yml config >/tmp/mercasto_compose_check.out
+
+echo "== Nginx config =="
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T mercasto-frontend nginx -t
+
+echo "== server-operator ${OPERATION} =="
+OPERATION="${OPERATION}" bash scripts/server-operator.sh "${OPERATION}"
+REMOTE


### PR DESCRIPTION
## Summary
Add a manual GitHub Actions live server gate workflow for read-only server checks.

## Risk
Low. Workflow-only change. The allowed operations are read-only.

## Smoke
CI should pass workflow validation and production checks.

## Rollback
Revert this PR to remove the live server gate workflow.