### PR TITLE
ops: trigger PR checks with decoupled live server gate

### DIFF
--- a/docs/pr-ci-trigger-7-2026-05-25.md
+++ b/docs/pr-ci-trigger-7-2026-05-25.md
@@ -1,0 +1,5 @@
+# PR CI trigger 7
+
+This file exists only to trigger PR checks after decoupling the read-only live server gate from Docker image builds.
+
+It is not launch approval evidence.


### PR DESCRIPTION
## Summary
Temporary PR to trigger pull_request-based Production checks after decoupling the read-only live server gate from Docker image builds.

## Risk
No production deploy, no migration, and no write operation to the production server is intended. The live server gate runs verify_quick only and public launch remains NO-GO until real server-side outputs and strict launch gates are reviewed.

## Smoke
Expected CI smoke: PR Quality Gate, Launch Artifact Inventory, Production checks with Live server gate verify_quick job starting after repository, compose, and SEO gates.

## Rollback
Close this PR and delete branch `run7`. Do not merge unless explicitly needed for audit cleanup.