### PR TITLE
DO NOT MERGE: diagnose share OG smoke live ad discovery

### DIFF
--- a/.github/workflows/production-checks.yml
+++ b/.github/workflows/production-checks.yml
@@ -137,4 +137,16 @@ jobs:
           SSH_USER: ${{ secrets.MERCASTO_SSH_USER }}
           SSH_KEY: ${{ secrets.MERCASTO_SSH_PRIVATE_KEY }}
           OPERATION: verify_quick
-        run: bash scripts/live-server-gate.sh "${OPERATION}"
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          bash scripts/live-server-gate.sh "${OPERATION}" 2>&1 | tee artifacts/live-server-gate-verify-quick.log
+
+      - name: Upload live server gate log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-server-gate-verify-quick-log
+          path: artifacts/live-server-gate-verify-quick.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/docs/live-server-gate-ssh-auth-troubleshooting.md
+++ b/docs/live-server-gate-ssh-auth-troubleshooting.md
@@ -1,0 +1,78 @@
+# Live server gate SSH auth troubleshooting
+
+This runbook supports issue #282. It is intentionally evidence-focused and must not include private keys, tokens, passwords, or repository secret values.
+
+## Current symptom
+
+The GitHub Actions live server gate reaches the production host, but SSH authentication fails before `/var/www/mercasto` checks can run:
+
+```text
+Permission denied (publickey,password).
+```
+
+This means `verify_quick` has not yet produced production application smoke evidence.
+
+## Safe evidence to compare
+
+Diagnostic PR #288 captured the public fingerprint derived from the Actions private key:
+
+```text
+SHA256:I+KFS74lO3ohSI5X3uAXHLlxk7TZyqO1ujLUOheZUPM
+```
+
+A public fingerprint is safe to record. Private key contents are not safe to print, paste, commit, or attach.
+
+## Trusted-shell checks
+
+Run these only on the production server or another trusted admin shell.
+
+### 1. Compare the server public key fingerprint
+
+```bash
+ssh-keygen -lf /root/.ssh/mercasto_actions_live_gate_ed25519.pub
+```
+
+Expected fingerprint:
+
+```text
+SHA256:I+KFS74lO3ohSI5X3uAXHLlxk7TZyqO1ujLUOheZUPM
+```
+
+If the fingerprint differs, the repository Actions private key does not match the server public key that is expected for the live gate.
+
+### 2. Verify the public key is authorized for root
+
+```bash
+grep -F "$(cat /root/.ssh/mercasto_actions_live_gate_ed25519.pub)" /root/.ssh/authorized_keys >/dev/null \
+  && echo "authorized_keys has live gate public key"
+```
+
+If the key is missing, append only the `.pub` file content. Do not paste private key material into shell history, logs, issues, or chat.
+
+```bash
+cat /root/.ssh/mercasto_actions_live_gate_ed25519.pub >> /root/.ssh/authorized_keys
+chmod 700 /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+```
+
+### 3. Verify sshd policy
+
+```bash
+sshd -T | grep -E 'permitrootlogin|pubkeyauthentication|authorizedkeysfile|passwordauthentication'
+```
+
+The live gate requires root public-key login to be allowed by the effective sshd configuration and by the key listed in `authorized_keys`.
+
+## Re-set repository secret from trusted shell
+
+If the server-side public key is correct but Actions uses a different fingerprint, re-set the matching private key using stdin redirection only:
+
+```bash
+gh secret set MERCASTO_SSH_PRIVATE_KEY --repo johnslimg-alt/mercasto < /root/.ssh/mercasto_actions_live_gate_ed25519
+```
+
+Do not pass secret values as command-line arguments.
+
+## Re-run evidence gate
+
+After fixing SSH authorization, re-run the failed Production checks jobs or trigger a fresh same-repo PR run. The issue is not complete until the live gate captures real server output from `/var/www/mercasto` and `verify_quick` completes without secret disclosure.

--- a/scripts/live-server-gate.sh
+++ b/scripts/live-server-gate.sh
@@ -22,9 +22,18 @@ esac
 
 install -m 700 -d ~/.ssh
 key_file="$(mktemp)"
-trap 'rm -f "${key_file}"' EXIT
+pub_file="${key_file}.pub"
+trap 'rm -f "${key_file}" "${pub_file}"' EXIT
 printf '%s\n' "${SSH_KEY}" >"${key_file}"
 chmod 600 "${key_file}"
+
+if ! ssh-keygen -y -f "${key_file}" >"${pub_file}" 2>/dev/null; then
+  echo "Invalid SSH private key format for live gate secret" >&2
+  exit 65
+fi
+
+echo "== Live gate SSH public key fingerprint =="
+ssh-keygen -lf "${pub_file}"
 
 ssh \
   -i "${key_file}" \

--- a/scripts/live-server-gate.sh
+++ b/scripts/live-server-gate.sh
@@ -6,7 +6,7 @@ SSH_HOST="${SSH_HOST:-}"
 SSH_PORT="${SSH_PORT:-22}"
 SSH_USER="${SSH_USER:-}"
 SSH_KEY="${SSH_KEY:-}"
-LIVE_GATE_SSH_DEBUG="${LIVE_GATE_SSH_DEBUG:-0}"
+LIVE_GATE_SSH_DEBUG="${LIVE_GATE_SSH_DEBUG:-1}"
 
 case "${OPERATION}" in
   status|verify_quick|security_smoke|seo_aeo_smoke) ;;

--- a/scripts/live-server-gate.sh
+++ b/scripts/live-server-gate.sh
@@ -6,6 +6,7 @@ SSH_HOST="${SSH_HOST:-}"
 SSH_PORT="${SSH_PORT:-22}"
 SSH_USER="${SSH_USER:-}"
 SSH_KEY="${SSH_KEY:-}"
+LIVE_GATE_SSH_DEBUG="${LIVE_GATE_SSH_DEBUG:-0}"
 
 case "${OPERATION}" in
   status|verify_quick|security_smoke|seo_aeo_smoke) ;;
@@ -35,14 +36,22 @@ fi
 echo "== Live gate SSH public key fingerprint =="
 ssh-keygen -lf "${pub_file}"
 
-ssh \
-  -i "${key_file}" \
-  -p "${SSH_PORT}" \
-  -o BatchMode=yes \
-  -o IdentitiesOnly=yes \
-  -o StrictHostKeyChecking=accept-new \
-  -o ServerAliveInterval=15 \
-  -o ServerAliveCountMax=4 \
+ssh_args=(
+  -i "${key_file}"
+  -p "${SSH_PORT}"
+  -o BatchMode=yes
+  -o IdentitiesOnly=yes
+  -o StrictHostKeyChecking=accept-new
+  -o ServerAliveInterval=15
+  -o ServerAliveCountMax=4
+)
+
+if [ "${LIVE_GATE_SSH_DEBUG}" = "1" ]; then
+  echo "== Live gate SSH debug enabled =="
+  ssh_args=(-vvv "${ssh_args[@]}")
+fi
+
+ssh "${ssh_args[@]}" \
   "${SSH_USER}@${SSH_HOST}" \
   "OPERATION='${OPERATION}' bash -s" <<'REMOTE'
 set -euo pipefail

--- a/scripts/share-og-smoke.sh
+++ b/scripts/share-og-smoke.sh
@@ -2,8 +2,59 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-https://mercasto.com}"
-AD_ID="${AD_ID:-1}"
+AD_ID="${AD_ID:-}"
 TMP_FILE="${TMPDIR:-/tmp}/mercasto-share-og-smoke.html"
+ADS_FILE="${TMPDIR:-/tmp}/mercasto-share-og-ads.json"
+
+command -v curl >/dev/null 2>&1 || {
+  echo "curl is required" >&2
+  exit 1
+}
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required" >&2
+  exit 1
+}
+
+if [ -z "$AD_ID" ]; then
+  ads_url="${BASE_URL%/}/api/ads?page=1"
+  ads_code="$(curl -k -sS --max-time 20 -o "$ADS_FILE" -w '%{http_code}' "$ads_url" || true)"
+  echo "$ads_url -> $ads_code"
+  if [ "$ads_code" != "200" ]; then
+    echo "FAIL: ads API returned HTTP $ads_code while discovering share smoke ad" >&2
+    exit 1
+  fi
+
+  AD_ID="$(python3 - "$ADS_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+
+items = []
+if isinstance(data, dict):
+    if isinstance(data.get("data"), list):
+        items = data["data"]
+    elif isinstance(data.get("data"), dict) and isinstance(data["data"].get("data"), list):
+        items = data["data"]["data"]
+    elif isinstance(data.get("ads"), list):
+        items = data["ads"]
+elif isinstance(data, list):
+    items = data
+
+for item in items:
+    if isinstance(item, dict) and item.get("id"):
+        print(item["id"])
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+)" || {
+    echo "FAIL: could not discover an ad id from /api/ads?page=1 for share OG smoke" >&2
+    exit 1
+  }
+fi
 
 url="${BASE_URL%/}/share/ads/${AD_ID}"
 code="$(curl -k -sS -L --max-time 20 -o "$TMP_FILE" -w '%{http_code}' "$url" || true)"


### PR DESCRIPTION
## Summary
Diagnostic-only PR for issue #282 live gate troubleshooting.

This PR currently does four diagnostic-only things:

1. Changes `scripts/share-og-smoke.sh` so the smoke test discovers a real ad id from `/api/ads?page=1` instead of assuming ad id `1` exists in production.
2. Adds temporary live gate log artifact capture to `.github/workflows/production-checks.yml` so failed `verify_quick` output can be reviewed when the MCP job log is truncated.
3. Prints only the public SSH key fingerprint derived from the live gate key material, not the private key, to compare against the server-side authorized public key.
4. Adds `docs/live-server-gate-ssh-auth-troubleshooting.md` with a safe runbook for comparing fingerprints and checking server SSH authorization without exposing secrets.

## Risk
Low runtime risk while this remains a draft diagnostic PR and is not merged into `main`. It does not change production runtime code, repository secrets, deploy keys, infrastructure, database schema, or live containers.

Do not merge this PR as a launch fix. It is evidence-gathering only unless separately reviewed and converted into a permanent safe diagnostics improvement.

## Smoke
Actual CI evidence so far:

- `PR Quality Gate` passed on diagnostic commit `45a83992ddb70ec6c3364ed5b864b7bacd86b43d`.
- `Launch Artifact Inventory` passed on diagnostic commit `45a83992ddb70ec6c3364ed5b864b7bacd86b43d`.
- `Production checks` run `26560028786` passed repository safety gates, Docker Compose validation, frontend build, frontend Docker image build, and SEO/AEO production smoke.
- `Production checks` run `26560028786` failed only on `Live server gate verify_quick`.
- Live gate job `78240535222` uploaded artifact `7259667613` / `live-server-gate-verify-quick-log`.

Captured public key fingerprint:

```text
256 SHA256:I+KFS74lO3ohSI5X3uAXHLlxk7TZyqO1ujLUOheZUPM mercasto-actions-live-gate (ED25519)
```

Captured SSH debug evidence:

```text
Authenticating to 72.62.173.145:22 as 'root'
Authentications that can continue: publickey,password
Will attempt key: /tmp/... ED25519 SHA256:I+KFS74lO3ohSI5X3uAXHLlxk7TZyqO1ujLUOheZUPM explicit
Offering public key: /tmp/... ED25519 SHA256:I+KFS74lO3ohSI5X3uAXHLlxk7TZyqO1ujLUOheZUPM explicit
Authentications that can continue: publickey,password
No more authentication methods to try.
root@72.62.173.145: Permission denied (publickey,password).
```

Conclusion: the Actions runner offers the expected ED25519 key, the server is reachable, and the server advertises public-key authentication, but the server rejects that offered key. The current blocker is server-side SSH authorization or root-login/account policy for that key/user, not a GitHub secret fingerprint mismatch and not a proven Laravel/app smoke failure.

## Rollback
Close this draft PR without merge and delete branch `ops/share-og-smoke-live-ad-discovery`. No production rollback is required because production runtime is unchanged.