### PR TITLE
style: match ad posting form to the site's real design tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     <meta name="twitter:image" content="https://mercasto.com/icon-512x512.png" />
     <!-- manifest non-critical: fetchpriority=low keeps it out of the critical path -->
     <link rel="manifest" href="/manifest.json" fetchpriority="low">
-    <title>Mercasto</title>
+    <title>Mercasto | Compra, Vende y Renta en Todo México</title>
     <!-- Google tag (gtag.js) — deferred off the critical path to protect load performance -->
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/scratch/split_translations.js
+++ b/scratch/split_translations.js
@@ -75,7 +75,7 @@ languages.forEach(lang => {
   // English fallback: if not ES, we merge EN manual translations for complete UI coverage
   const enManual = translationsObj['en'] || {};
   
-  let merged = {};
+  let merged;
   if (lang === 'es') {
     merged = { ...manual };
   } else if (lang === 'en') {

--- a/src/components/screens/PostScreen.jsx
+++ b/src/components/screens/PostScreen.jsx
@@ -14,15 +14,6 @@ const API_URL = import.meta.env.VITE_API_BASE_URL || 'https://mercasto.com/api';
 
 const MEXICO_STATES = Object.keys(mexicoLocations);
 
-/* ============================== TOKENS ============================== */
-const INK = "#1C1B19";
-const BG = "#F7F5EE";
-const TEAL = "#0E6E6B";
-const PINK = "#D6336C";
-const LINE = "#E4E0D4";
-const FONT_HEAD = "'Fraunces', Georgia, serif";
-const FONT_BODY = "'Inter', system-ui, sans-serif";
-
 const STEP_LABELS = ['Categoría', 'Detalles', 'Contacto'];
 
 const CATEGORY_ICONS = {
@@ -49,19 +40,16 @@ const CONTACT_METHODS = [
   { id: 'telegram', label: 'Telegram', icon: Send, hint: 'Usuario' },
 ];
 
-const selectClass = "w-full min-h-[48px] rounded-xl border px-4 py-3 text-[15px] outline-none transition-shadow cursor-pointer bg-white";
-const inputClass = "w-full min-h-[48px] rounded-xl border px-4 py-3 text-[15px] outline-none transition-shadow bg-white";
-const focusHandlers = {
-  onFocus: (e) => { e.target.style.borderColor = TEAL; e.target.style.boxShadow = `0 0 0 3px ${TEAL}22`; },
-  onBlur: (e) => { e.target.style.borderColor = LINE; e.target.style.boxShadow = "none"; },
-};
+const fieldClass = 'w-full px-3.5 py-2.5 border border-slate-300 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500';
+const selectFieldClass = fieldClass + ' cursor-pointer';
+const labelClass = 'block text-[13px] font-semibold text-slate-700 dark:text-slate-300 mb-2';
 
-function Field({ label, optional, required, children }) {
+function Field({ label, required, optional, children, className = '' }) {
   return (
-    <div className="w-full" style={{ fontFamily: FONT_BODY }}>
+    <div className={className}>
       {label && (
-        <label className="block text-sm font-medium mb-1.5" style={{ color: INK }}>
-          {label}{required && <span style={{ color: PINK }}> *</span>}{optional && <span className="opacity-50 font-normal"> (opcional)</span>}
+        <label className={labelClass}>
+          {label}{required && <span className="text-red-500 ml-1">*</span>}{optional && <span className="opacity-60 font-normal"> (opcional)</span>}
         </label>
       )}
       {children}
@@ -71,28 +59,19 @@ function Field({ label, optional, required, children }) {
 
 function Stepper({ step }) {
   return (
-    <div className="flex items-center justify-center gap-0 mb-6 md:mb-8" style={{ fontFamily: FONT_BODY }}>
-      {STEP_LABELS.map((s, i) => {
+    <div className="flex justify-between items-center mb-8 border-b border-slate-100 dark:border-slate-800 pb-5">
+      {STEP_LABELS.map((label, i) => {
         const n = i + 1;
-        const active = step === n, done = step > n;
+        const active = step === n;
+        const done = step > n;
         return (
-          <div key={s} className="flex items-center">
-            <div className="flex flex-col items-center">
-              <div
-                className="flex h-9 w-9 md:h-10 md:w-10 items-center justify-center rounded-full text-sm font-semibold transition-colors"
-                style={{
-                  background: done ? TEAL : active ? INK : "#FFF",
-                  color: done || active ? "#FFF" : "#8A867B",
-                  border: done || active ? "none" : `1.5px solid ${LINE}`,
-                }}
-              >
-                {done ? <Check size={16} /> : n}
-              </div>
-              <span className="mt-1.5 text-[11px] md:text-xs font-medium" style={{ color: active ? INK : "#8A867B" }}>{s}</span>
-            </div>
-            {i < STEP_LABELS.length - 1 && (
-              <div className="mx-2 md:mx-4 mb-5 h-[2px] w-10 md:w-20 rounded" style={{ background: step > n ? TEAL : LINE }} />
-            )}
+          <div key={label} className="flex items-center gap-2">
+            <span className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold ${active ? 'bg-[#84CC16] text-white shadow-md' : done ? 'bg-[#84CC16]/25 text-[#65A30D]' : 'bg-slate-100 dark:bg-slate-800 text-slate-400'}`}>
+              {done ? <Check size={14} /> : n}
+            </span>
+            <span className={`text-xs md:text-sm font-semibold ${active ? 'text-slate-950 dark:text-white' : 'text-slate-400'}`}>
+              {label}
+            </span>
           </div>
         );
       })}
@@ -284,58 +263,70 @@ export default function PostScreen({
     const val = form.attributes?.[key] || '';
     const errKey = `attr_${key}`;
     const hasErr = !!errors[errKey];
+    const baseClass = `w-full px-3.5 py-2.5 border ${hasErr ? 'border-red-400' : 'border-slate-300 dark:border-slate-700'} rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] bg-white dark:bg-slate-950 text-slate-900 dark:text-white transition-all`;
     const onChange = v => setForm(prev => ({ ...prev, attributes: { ...(prev.attributes || {}), [key]: v } }));
 
     if (field.type === 'select' && field.options?.length > 0) {
       return (
-        <Field key={key} label={field.label || key} required={field.required}>
-          <select value={val} onChange={e => onChange(e.target.value)} className={selectClass} style={{ borderColor: hasErr ? PINK : LINE }}>
+        <div key={key} className="space-y-2">
+          <label className="block text-[13px] font-semibold text-slate-700 dark:text-slate-300">
+            {field.label || key}{field.required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+          <select value={val} onChange={e => onChange(e.target.value)} className={baseClass + ' cursor-pointer'}>
             <option value="">Seleccionar...</option>
             {field.options.map(o => <option key={o} value={o}>{o}</option>)}
           </select>
-          {hasErr && <p className="text-xs mt-1" style={{ color: PINK }}>{errors[errKey]}</p>}
-        </Field>
+          {hasErr && <p className="text-xs text-red-500">{errors[errKey]}</p>}
+        </div>
       );
     }
     if (field.type === 'number' || field.type === 'range') {
       return (
-        <Field key={key} label={field.label || key} required={field.required}>
-          <input type="number" value={val} onChange={e => onChange(e.target.value)} placeholder={field.placeholder || ''} className={inputClass} style={{ borderColor: hasErr ? PINK : LINE }} {...focusHandlers} />
-          {hasErr && <p className="text-xs mt-1" style={{ color: PINK }}>{errors[errKey]}</p>}
-        </Field>
+        <div key={key} className="space-y-2">
+          <label className="block text-[13px] font-semibold text-slate-700 dark:text-slate-300">
+            {field.label || key}{field.required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+          <input type="number" value={val} onChange={e => onChange(e.target.value)} placeholder={field.placeholder || ''} className={baseClass} />
+          {hasErr && <p className="text-xs text-red-500">{errors[errKey]}</p>}
+        </div>
       );
     }
     return (
-      <Field key={key} label={field.label || key} required={field.required}>
-        <input type="text" value={val} onChange={e => onChange(e.target.value)} placeholder={field.placeholder || ''} className={inputClass} style={{ borderColor: hasErr ? PINK : LINE }} {...focusHandlers} />
-        {hasErr && <p className="text-xs mt-1" style={{ color: PINK }}>{errors[errKey]}</p>}
-      </Field>
+      <div key={key} className="space-y-2">
+        <label className="block text-[13px] font-semibold text-slate-700 dark:text-slate-300">
+          {field.label || key}{field.required && <span className="text-red-500 ml-1">*</span>}
+        </label>
+        <input type="text" value={val} onChange={e => onChange(e.target.value)} placeholder={field.placeholder || ''} className={baseClass} />
+        {hasErr && <p className="text-xs text-red-500">{errors[errKey]}</p>}
+      </div>
     );
   };
 
   return (
-    <div className="min-h-screen pb-28 md:pb-12" style={{ background: BG, fontFamily: FONT_BODY, color: INK }}>
-      <style>{`@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Inter:wght@400;500;600;700&display=swap');`}</style>
+    <div className="bg-[var(--paper)] min-h-screen w-full flex items-start justify-center py-6 md:py-10 px-4 pb-28 md:pb-10">
+      <div className="w-full max-w-3xl bg-white dark:bg-slate-950 rounded-2xl md:rounded-3xl border border-slate-200 dark:border-slate-800 p-6 md:p-10 shadow-sm">
 
-      <main className="mx-auto max-w-3xl px-4 py-6 md:py-10">
-        <h1
-          className="mb-1 text-center text-2xl md:text-3xl font-bold flex items-center justify-center gap-2 cursor-pointer"
-          style={{ fontFamily: FONT_HEAD }}
+        {/* Header */}
+        <h2
+          className="text-[22px] font-bold tracking-tight text-slate-900 dark:text-white mb-6 flex items-center gap-2 cursor-pointer"
           onClick={() => editingAd && setEditingAd(null)}
         >
-          {editingAd ? (t.edit_ad || 'Editar anuncio') : (t.post_title || 'Publica tu anuncio')}
-        </h1>
-        <p className="mb-6 text-center text-sm" style={{ color: '#8A867B' }}>Gratis y en pocos minutos</p>
+          <PlusCircle className="text-[#84CC16]" size={26} />
+          {editingAd ? t.edit_ad || 'Editar anuncio' : t.post_title}
+        </h2>
 
         <Stepper step={step} />
 
         {/* KEY FIX: noValidate disables browser HTML5 validation */}
-        <form onSubmit={handleFinalSubmit} noValidate className="rounded-2xl border bg-white p-5 md:p-8 space-y-6" style={{ borderColor: LINE }}>
+        <form onSubmit={handleFinalSubmit} noValidate className="space-y-6">
 
           {/* ══════════════ STEP 1 — Categoría ══════════════ */}
           {step === 1 && (
-            <div className="space-y-6">
-              <Field label="Categoría">
+            <div className="space-y-6 animate-in fade-in duration-300">
+              <div>
+                <label className="block text-[14px] font-bold text-slate-700 dark:text-slate-300 mb-3">
+                  Selecciona una Categoría
+                </label>
                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
                   {categoriesData.map(cat => {
                     const Icon = CATEGORY_ICONS[cat.slug] || Tag;
@@ -345,139 +336,158 @@ export default function PostScreen({
                         key={cat.slug}
                         type="button"
                         onClick={() => setForm({ ...form, category: cat.slug, subcategory: '', attributes: {} })}
-                        className="flex flex-col items-center justify-center p-4 rounded-xl border text-center transition-all"
-                        style={{
-                          borderColor: selected ? TEAL : LINE,
-                          borderWidth: selected ? 2 : 1,
-                          background: selected ? `${TEAL}0D` : '#FFF',
-                        }}
+                        className={`flex flex-col items-center justify-center p-4 rounded-xl border text-center transition-all ${selected ? 'border-[#84CC16] bg-[#F7FEE7] dark:bg-slate-900/60 ring-2 ring-[#84CC16]' : 'border-slate-200 dark:border-slate-800 hover:border-[#84CC16] hover:bg-slate-50 dark:hover:bg-slate-800'}`}
                       >
-                        <Icon size={24} style={{ color: selected ? TEAL : '#8A867B' }} />
-                        <span className="text-[13px] font-semibold mt-2" style={{ color: INK }}>
+                        <Icon size={24} className={selected ? 'text-[#65A30D]' : 'text-slate-500'} />
+                        <span className="text-[13px] font-bold mt-2 text-slate-800 dark:text-slate-100">
                           {cat.name?.[lang] || cat.name?.es || cat.slug}
                         </span>
                       </button>
                     );
                   })}
                 </div>
-              </Field>
+              </div>
 
               {form.category && (subcategoriesMap[form.category] || []).length > 0 && (
-                <Field label="Subcategoría">
+                <div className="mt-4 animate-in fade-in slide-in-from-top-4 duration-300">
+                  <label className="block text-[14px] font-bold text-slate-700 dark:text-slate-300 mb-3">
+                    Selecciona una Subcategoría
+                  </label>
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                     {(subcategoriesMap[form.category] || []).map(sub => (
                       <button
                         key={sub}
                         type="button"
                         onClick={() => setForm({ ...form, subcategory: sub })}
-                        className="p-3 rounded-xl border text-center transition-all text-xs font-semibold"
-                        style={{
-                          borderColor: form.subcategory === sub ? TEAL : LINE,
-                          borderWidth: form.subcategory === sub ? 2 : 1,
-                          background: form.subcategory === sub ? `${TEAL}0D` : '#FFF',
-                          color: form.subcategory === sub ? TEAL : INK,
-                        }}
+                        className={`p-3 rounded-lg border text-center transition-all text-xs font-semibold ${form.subcategory === sub ? 'border-[#84CC16] bg-[#F7FEE7] dark:bg-slate-900/60 ring-2 ring-[#84CC16]' : 'border-slate-200 dark:border-slate-800 hover:border-[#84CC16] hover:bg-slate-50 dark:hover:bg-slate-800'}`}
                       >
                         {sub}
                       </button>
                     ))}
                   </div>
-                </Field>
+                </div>
               )}
+
+              <div className="hidden md:flex justify-end pt-6">
+                <button
+                  type="button"
+                  disabled={!form.category || ((subcategoriesMap[form.category] || []).length > 0 && !form.subcategory)}
+                  onClick={goNext}
+                  className="btn-lg bg-[#0F172A] text-white hover:bg-black flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Siguiente <ChevronRight size={16} />
+                </button>
+              </div>
             </div>
           )}
 
           {/* ══════════════ STEP 2 — Detalles ══════════════ */}
           {step === 2 && (
-            <div className="space-y-6">
-              <Field label={t.ad_title || 'Título del anuncio'}>
+            <div className="space-y-6 animate-in fade-in duration-300">
+
+              {/* Title */}
+              <div>
+                <label className={labelClass}>{t.ad_title}</label>
                 <input
                   value={form.title}
                   onChange={e => { setForm({ ...form, title: e.target.value }); if (errors.title) setErrors(p => ({ ...p, title: null })); }}
-                  className={inputClass} style={{ borderColor: errors.title ? PINK : LINE }} {...focusHandlers}
+                  className={`w-full px-3.5 py-2.5 border ${errors.title ? 'border-red-400' : 'border-slate-300 dark:border-slate-700'} rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white`}
                   placeholder="Ej: Honda Civic 2018"
                 />
-                {errors.title && <p className="text-xs mt-1" style={{ color: PINK }}>{errors.title}</p>}
-              </Field>
+                {errors.title && <p className="text-xs text-red-500 mt-1">{errors.title}</p>}
+              </div>
 
-              {/* PHOTOS */}
-              <Field label={t.ad_photos || 'Fotos'}>
-                <span className="block -mt-1 mb-2 text-xs" style={{ color: '#8A867B' }}>{images.length}/10</span>
+              {/* Photos */}
+              <div>
+                <label className={labelClass}>
+                  {t.ad_photos || 'Fotos del anuncio'} <span className="font-normal text-slate-400">({images.length}/10)</span>
+                </label>
                 {images.length > 0 ? (
                   <div className="w-full space-y-3">
                     <SortablePhotoGrid photos={images} onReorder={reorderImages} onDelete={removeImageById || removeImage} />
                     {images.length < 10 && (
-                      <label className="aspect-square border-2 border-dashed rounded-xl flex flex-col items-center justify-center text-center transition-all cursor-pointer w-full py-4" style={{ borderColor: LINE }}>
+                      <label className="aspect-square border-2 border-dashed border-slate-300 dark:border-slate-700 rounded-xl flex flex-col items-center justify-center text-center hover:bg-[#84CC16]/5 hover:border-[#84CC16]/50 transition-all cursor-pointer bg-slate-50 dark:bg-slate-950 w-full py-4">
                         <input type="file" multiple accept="image/jpeg,image/png,image/webp,image/gif" onChange={handleImageChange} className="hidden" />
-                        <Camera style={{ color: TEAL }} size={22} />
-                        <span className="text-xs font-medium mt-1" style={{ color: TEAL }}>Agregar</span>
+                        <PlusCircle className="text-slate-400" size={22} />
+                        <span className="text-xs text-slate-400 mt-1">{t.add_more_photos || 'Agregar más fotos'}</span>
                       </label>
                     )}
                   </div>
                 ) : (
-                  <label className="border-2 border-dashed rounded-2xl p-8 flex flex-col items-center justify-center text-center transition-all cursor-pointer h-40 md:h-48" style={{ borderColor: LINE }}>
+                  <label className="border-2 border-dashed border-slate-300 dark:border-slate-700 rounded-2xl p-8 flex flex-col items-center justify-center text-center hover:bg-[#84CC16]/5 hover:border-[#84CC16]/50 transition-all cursor-pointer h-40 md:h-48 bg-slate-50 dark:bg-slate-950">
                     <input type="file" multiple accept="image/jpeg,image/png,image/webp,image/gif" onChange={handleImageChange} className="hidden" />
-                    <div className="w-14 h-14 rounded-full flex items-center justify-center mb-3" style={{ background: `${TEAL}0D` }}>
-                      <Camera style={{ color: TEAL }} size={28} />
+                    <div className="w-14 h-14 bg-white dark:bg-slate-900 rounded-full flex items-center justify-center mb-3 shadow-sm">
+                      <Camera className="text-slate-400" size={28} />
                     </div>
-                    <p className="text-[14px] font-medium" style={{ color: INK }}>{t.drag_photos_hint || 'Arrastra tus fotos aquí o'} <span style={{ color: TEAL }}>{t.browse_label || 'explora'}</span></p>
-                    <p className="text-[12px] mt-1" style={{ color: '#8A867B' }}>{t.max_photos_hint || 'Máximo 10 fotos (JPG, PNG)'}</p>
+                    <p className="text-[14px] font-medium text-slate-700 dark:text-slate-200 mb-1">
+                      {t.drag_photos_hint || 'Arrastra tus fotos aquí o'} <span className="text-[#65A30D]">{t.browse_label || 'explora'}</span>
+                    </p>
+                    <p className="text-[12px] text-slate-500">{t.max_photos_hint || 'Máximo 10 fotos (JPG, PNG)'}</p>
                   </label>
                 )}
-              </Field>
+              </div>
 
-              {/* VIDEO */}
-              <Field label={t.video_hint || 'Video (opcional, MP4, máx. 50MB)'}>
+              {/* Video */}
+              <div>
+                <label className={labelClass}>{t.video_hint || 'Video (Opcional, MP4, max 50MB)'}</label>
                 {videoFile ? (
-                  <div className="flex items-center gap-3 p-2 rounded-xl border" style={{ borderColor: LINE }}>
-                    <Video style={{ color: '#8A867B' }} />
-                    <span className="text-sm truncate flex-1">{videoFile.name}</span>
-                    <button type="button" onClick={() => setVideoFile(null)} style={{ color: PINK }}><Trash2 size={16} /></button>
+                  <div className="flex items-center gap-3 p-2 bg-slate-100 dark:bg-slate-950 rounded-xl border border-slate-200 dark:border-slate-800">
+                    <Video className="text-slate-500" />
+                    <span className="text-sm text-slate-700 dark:text-slate-300 truncate flex-1">{videoFile.name}</span>
+                    <button type="button" onClick={() => setVideoFile(null)} className="p-1 text-slate-400 hover:text-red-500">
+                      <Trash2 size={16} />
+                    </button>
                   </div>
                 ) : (
-                  <label className="flex items-center gap-3 p-3 border border-dashed rounded-xl cursor-pointer" style={{ borderColor: LINE }}>
+                  <label className="flex items-center gap-3 p-3 bg-slate-50 dark:bg-slate-950 border border-dashed border-slate-300 dark:border-slate-700 rounded-xl hover:bg-[#84CC16]/5 hover:border-[#84CC16]/50 transition-all cursor-pointer">
                     <input type="file" accept="video/mp4,video/quicktime" onChange={e => setVideoFile(e.target.files[0])} className="hidden" />
-                    <div className="w-10 h-10 rounded-lg flex items-center justify-center border" style={{ borderColor: LINE }}>
-                      <Video style={{ color: TEAL }} size={20} />
+                    <div className="w-10 h-10 bg-white dark:bg-slate-900 rounded-lg flex items-center justify-center border border-slate-200 dark:border-slate-800">
+                      <Video className="text-[#65A30D]" size={20} />
                     </div>
-                    <div className="flex-1 text-left">
-                      <p className="text-[13px] font-bold" style={{ color: INK }}>{t.video_opt || 'Subir video'}</p>
-                      <p className="text-[11px]" style={{ color: '#8A867B' }}>{t.no_file_selected || 'Sin archivo seleccionado'}</p>
+                    <div>
+                      <p className="text-[13px] font-bold text-slate-700 dark:text-slate-200">{t.video_opt || 'Subir video'}</p>
+                      <p className="text-[11px] text-slate-500">{t.no_file_selected || 'Sin archivo seleccionado'}</p>
                     </div>
                   </label>
                 )}
-              </Field>
+              </div>
 
-              {/* CONDITION + PRICE */}
+              {/* Condition + Price */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                <Field label={t.condition || 'Estado'}>
-                  <select value={form.condition} onChange={e => setForm({ ...form, condition: e.target.value })} className={selectClass} style={{ borderColor: LINE }}>
+                <div>
+                  <label className={labelClass}>{t.condition || 'Estado'}</label>
+                  <select
+                    value={form.condition}
+                    onChange={e => setForm({ ...form, condition: e.target.value })}
+                    className={selectFieldClass}
+                  >
                     <option value="nuevo">{t.new || 'Nuevo'}</option>
                     <option value="usado">{t.used || 'Usado'}</option>
                   </select>
-                </Field>
-                <Field label={t.ad_price || 'Precio'}>
+                </div>
+                <div>
+                  <label className={labelClass}>{t.ad_price}</label>
                   <div className="relative">
-                    <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[15px]" style={{ color: '#8A867B' }}>$</span>
+                    <span className="absolute left-3.5 top-1/2 -translate-y-1/2 font-medium text-slate-400 text-[14px]">$</span>
                     <input
                       type="number"
                       value={form.price}
                       onChange={e => { setForm({ ...form, price: e.target.value }); if (errors.price) setErrors(p => ({ ...p, price: null })); }}
-                      className={inputClass} style={{ borderColor: errors.price ? PINK : LINE, paddingLeft: '2.6rem' }} {...focusHandlers}
+                      className={`w-full px-3.5 py-2.5 pl-7 border ${errors.price ? 'border-red-400' : 'border-slate-300 dark:border-slate-700'} rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white`}
                       placeholder="0.00"
                     />
                   </div>
-                  {errors.price && <p className="text-xs mt-1" style={{ color: PINK }}>{errors.price}</p>}
-                </Field>
+                  {errors.price && <p className="text-xs text-red-500 mt-1">{errors.price}</p>}
+                </div>
               </div>
 
-              {/* DYNAMIC ATTRIBUTES */}
+              {/* Dynamic attributes */}
               {form.category && (attributesLoading || dynamicAttributes.length > 0) && (
-                <div className="border rounded-2xl p-5" style={{ borderColor: LINE, background: `${TEAL}05` }}>
-                  <h3 className="text-[14px] font-bold mb-4 flex items-center gap-2" style={{ fontFamily: FONT_HEAD, color: INK }}>
-                    <Zap size={16} style={{ color: TEAL }} />
+                <div className="border border-slate-200 dark:border-slate-800 rounded-2xl p-5 bg-slate-50/50 dark:bg-slate-950/50">
+                  <h3 className="text-[14px] font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+                    <Zap size={16} className="text-[#84CC16]" />
                     {t.ad_attributes || 'Características del anuncio'}
-                    {attributesLoading && <Loader2 size={14} className="animate-spin" style={{ color: '#8A867B' }} />}
+                    {attributesLoading && <Loader2 size={14} className="animate-spin text-slate-400" />}
                   </h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     {dynamicAttributes.map(field => renderAttrField(field))}
@@ -485,38 +495,39 @@ export default function PostScreen({
                 </div>
               )}
 
-              {/* DETALLES DE VENTA (фасеты для фильтров поиска) */}
-              <div className="border rounded-2xl p-5" style={{ borderColor: LINE, background: `${TEAL}05` }}>
-                <h3 className="text-[14px] font-bold mb-4 flex items-center gap-2" style={{ fontFamily: FONT_HEAD, color: INK }}>
-                  <Zap size={16} style={{ color: TEAL }} />
+              {/* Detalles de venta (фасеты для фильтров поиска) */}
+              <div className="border border-slate-200 dark:border-slate-800 rounded-2xl p-5 bg-slate-50/50 dark:bg-slate-950/50">
+                <h3 className="text-[14px] font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+                  <Zap size={16} className="text-[#84CC16]" />
                   {t.sale_details || 'Detalles de venta'}
                 </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {SALE_FACETS.map(f => (
-                    <Field key={f.key} label={f.label}>
+                    <div key={f.key} className="space-y-2">
+                      <label className="block text-[13px] font-semibold text-slate-700 dark:text-slate-300">{f.label}</label>
                       <select
                         value={form.attributes?.[f.key] || ''}
                         onChange={e => setForm(prev => ({ ...prev, attributes: { ...(prev.attributes || {}), [f.key]: e.target.value } }))}
-                        className={selectClass} style={{ borderColor: LINE }}
+                        className={selectFieldClass}
                       >
                         <option value="">{t.select_optional || 'Seleccionar (opcional)...'}</option>
                         {f.options.map(o => <option key={o} value={o}>{o}</option>)}
                       </select>
-                    </Field>
+                    </div>
                   ))}
                 </div>
               </div>
 
-              {/* DESCRIPTION */}
-              <Field label={t.ad_desc || 'Descripción'}>
-                <div className="flex items-center justify-end mb-2">
+              {/* AI Description */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label className={labelClass + ' mb-0'}>{t.ad_desc}</label>
                   {handleGenerateDescription && (
                     <button
                       type="button"
                       onClick={handleGenerateDescription}
                       disabled={aiLoading}
-                      className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[12px] font-medium disabled:opacity-50 transition-colors"
-                      style={{ color: TEAL }}
+                      className="flex items-center gap-1.5 text-xs font-semibold text-[#65A30D] hover:text-[#84CC16] disabled:opacity-50 transition-colors"
                     >
                       {aiLoading ? <Loader2 size={13} className="animate-spin" /> : <Sparkles size={13} />}
                       {t.generate_ai || 'Generar con IA'}
@@ -526,37 +537,56 @@ export default function PostScreen({
                 <textarea
                   value={form.description}
                   onChange={e => { setForm({ ...form, description: e.target.value }); if (errors.description) setErrors(p => ({ ...p, description: null })); }}
-                  className="w-full rounded-xl border px-4 py-3 text-[15px] outline-none h-32 resize-none"
-                  style={{ borderColor: errors.description ? PINK : LINE }} {...focusHandlers}
-                  placeholder={t.ad_desc || 'Describe tu artículo...'}
+                  className={`w-full px-3.5 py-2.5 border ${errors.description ? 'border-red-400' : 'border-slate-300 dark:border-slate-700'} rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all min-h-[140px] bg-white dark:bg-slate-950 text-slate-900 dark:text-white`}
+                  placeholder={t.ad_desc}
                 />
-                {errors.description && <p className="text-xs mt-1" style={{ color: PINK }}>{errors.description}</p>}
-              </Field>
+                {errors.description && <p className="text-xs text-red-500 mt-1">{errors.description}</p>}
+              </div>
+
+              {/* Step 2 navigation */}
+              <div className="hidden md:flex justify-between items-center pt-6">
+                <button type="button" onClick={goBack} className="btn-lg border border-slate-200 text-slate-700 hover:bg-slate-50 flex items-center gap-1.5">
+                  <ChevronLeft size={16} /> Atrás
+                </button>
+                <button type="button" onClick={goNext} className="btn-lg bg-[#0F172A] text-white hover:bg-black flex items-center gap-1.5">
+                  Siguiente <ChevronRight size={16} />
+                </button>
+              </div>
             </div>
           )}
 
           {/* ══════════════ STEP 3 — Contacto ══════════════ */}
           {step === 3 && (
-            <div className="space-y-6">
+            <div className="space-y-6 animate-in fade-in duration-300">
+
+              {/* State + City */}
               <div>
-                <h2 className="mb-3 text-lg font-bold" style={{ fontFamily: FONT_HEAD, color: INK }}>Ubicación</h2>
+                <h3 className="text-[14px] font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+                  <MapPin size={16} className="text-[#84CC16]" /> Ubicación
+                </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                  <Field label={t.state || 'Estado'} required>
+                  <div>
+                    <label className={labelClass}>
+                      {t.state || 'Estado'} <span className="text-red-500">*</span>
+                    </label>
                     <select
                       value={form.state || ''}
                       onChange={e => {
                         setForm({ ...form, state: e.target.value, city: '', location: e.target.value });
                         setCustomCity(false);
                       }}
-                      className={selectClass} style={{ borderColor: LINE }}
+                      className={selectFieldClass}
                     >
                       <option value="">{t.select_state || 'Seleccionar estado'}</option>
                       {MEXICO_STATES.map(s => <option key={s} value={s}>{s}</option>)}
                     </select>
-                  </Field>
+                  </div>
 
                   {form.state && (
-                    <Field label={t.city || 'Ciudad'} required>
+                    <div>
+                      <label className={labelClass}>
+                        {t.city || 'Ciudad'} <span className="text-red-500">*</span>
+                      </label>
                       {customCity ? (
                         <div className="flex gap-2">
                           <input
@@ -567,15 +597,14 @@ export default function PostScreen({
                               setForm(prev => ({ ...prev, city: v, location: v ? `${v}, ${prev.state}` : prev.state }));
                             }}
                             placeholder="Escribe el nombre de tu ciudad"
-                            className={inputClass} style={{ borderColor: LINE }} {...focusHandlers}
+                            className={fieldClass}
                           />
                           <button
                             type="button"
                             onClick={() => { setCustomCity(false); setForm(prev => ({ ...prev, city: '' })); }}
-                            className="px-3 py-2 border rounded-xl text-xs font-semibold whitespace-nowrap"
-                            style={{ borderColor: LINE, color: '#8A867B' }}
+                            className="px-3 py-2 border border-slate-200 dark:border-slate-700 rounded-xl text-xs font-semibold text-slate-500 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors whitespace-nowrap"
                           >
-                            Elegir de la lista
+                            Seleccionar de la lista
                           </button>
                         </div>
                       ) : (
@@ -590,69 +619,74 @@ export default function PostScreen({
                               setForm(prev => ({ ...prev, city: v, location: v ? `${v}, ${prev.state}` : prev.state }));
                             }
                           }}
-                          className={selectClass} style={{ borderColor: LINE }}
+                          className={selectFieldClass}
                         >
                           <option value="">{t.select_city || 'Seleccionar ciudad'}</option>
                           {(mexicoLocations[form.state] || []).map(c => <option key={c} value={c}>{c}</option>)}
-                          <option value="otro">Otro (escribir manualmente)...</option>
+                          <option value="otro">Otro (Escribir manualmente)...</option>
                         </select>
                       )}
-                    </Field>
+                    </div>
                   )}
                 </div>
 
-                <Field label={t.location || 'Dirección específica / ubicación'}>
-                  <div className="relative mt-1.5 mb-3">
-                    <MapPin className="absolute left-4 top-1/2 -translate-y-1/2" style={{ color: '#8A867B' }} size={18} />
+                {/* Location + Map */}
+                <div className="mt-5">
+                  <label className={labelClass}>
+                    {t.location || 'Dirección específica / Ubicación'}
+                  </label>
+                  <div className="relative mb-3">
+                    <MapPin className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
                     <input
                       value={form.location || ''}
                       onChange={e => setForm({ ...form, location: e.target.value })}
-                      className={inputClass} style={{ borderColor: LINE, paddingLeft: '2.6rem' }} {...focusHandlers}
+                      className="w-full px-3.5 py-2.5 pl-10 border border-slate-300 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
                       placeholder={t.loc_placeholder || 'Escribe tu dirección o haz clic en el mapa'}
                     />
                   </div>
-                </Field>
 
-                <div className="mb-3 flex justify-end">
-                  <button
-                    type="button"
-                    onClick={handleGPS}
-                    disabled={gpsLoading}
-                    className="px-4 py-2.5 font-bold rounded-xl text-xs flex items-center gap-1.5 transition-all disabled:opacity-50 text-white"
-                    style={{ background: TEAL }}
-                  >
-                    {gpsLoading ? <Loader2 size={14} className="animate-spin" /> : <Locate size={14} />}
-                    Usar GPS actual
-                  </button>
-                </div>
+                  <div className="mb-3 flex justify-end">
+                    <button
+                      type="button"
+                      onClick={handleGPS}
+                      disabled={gpsLoading}
+                      className="px-4 py-2 bg-[#84CC16] hover:bg-[#65A30D] text-slate-950 font-bold rounded-xl text-xs flex items-center gap-1.5 transition-all shadow-sm disabled:opacity-50"
+                    >
+                      {gpsLoading ? <Loader2 size={14} className="animate-spin" /> : <Locate size={14} />}
+                      Usar GPS actual
+                    </button>
+                  </div>
 
-                <p className="text-[12px] mb-2" style={{ color: '#8A867B' }}>{t.tap_map_hint || 'Toca el mapa para marcar la ubicación exacta de tu anuncio.'}</p>
-                <div className="w-full h-64 rounded-xl overflow-hidden border relative" style={{ borderColor: LINE, background: '#EFEDE4' }}>
-                  {isMapUpdating && <div className="absolute inset-0 flex items-center justify-center" style={{ background: 'rgba(247,245,238,.6)' }}><Loader2 className="w-8 h-8 animate-spin" style={{ color: TEAL }} /></div>}
-                  <MapV3
-                    locationPicker
-                    showFullscreen={false}
-                    locationQuery={mapQuery}
-                    markers={form.latitude && form.longitude ? [{ label: t.selected_label || 'Seleccionado', coords: [Number(form.latitude), Number(form.longitude)], tone: 'lime' }] : []}
-                    onLocationSelect={({ lat, lng }) => setForm(prev => ({ ...prev, latitude: lat, longitude: lng }))}
-                    className="h-full rounded-none border-0 shadow-none"
-                  />
+                  <p className="text-[12px] text-slate-500 dark:text-slate-400 mb-2">{t.tap_map_hint || 'Toca el mapa para marcar la ubicación exacta de tu anuncio.'}</p>
+                  <div className="w-full h-64 rounded-xl overflow-hidden border border-slate-200 dark:border-slate-700 relative">
+                    {isMapUpdating && <div className="absolute inset-0 flex items-center justify-center bg-slate-100/50 dark:bg-slate-900/50"><Loader2 className="w-8 h-8 text-[#84CC16] animate-spin" /></div>}
+                    <MapV3
+                      locationPicker
+                      showFullscreen={false}
+                      locationQuery={mapQuery}
+                      markers={form.latitude && form.longitude ? [{ label: t.selected_label || 'Seleccionado', coords: [Number(form.latitude), Number(form.longitude)], tone: 'lime' }] : []}
+                      onLocationSelect={({ lat, lng }) => setForm(prev => ({ ...prev, latitude: lat, longitude: lng }))}
+                      className="h-full rounded-none border-0 shadow-none"
+                    />
+                  </div>
                 </div>
               </div>
 
-              <div>
-                <h2 className="mb-3 text-lg font-bold" style={{ fontFamily: FONT_HEAD, color: INK }}>¿Cómo te contactan?</h2>
+              {/* Contact methods */}
+              <div className="border border-slate-200 dark:border-slate-800 rounded-2xl p-5 bg-slate-50/50 dark:bg-slate-950/50">
+                <h3 className="text-[14px] font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+                  <MessageCircle size={16} className="text-[#84CC16]" /> ¿Cómo te contactan?
+                </h3>
                 <div className="grid grid-cols-3 gap-2 md:gap-3">
                   {CONTACT_METHODS.map((m) => {
                     const sel = contactMethods.includes(m.id);
                     return (
                       <button key={m.id} type="button"
                         onClick={() => setContactMethods(sel ? contactMethods.filter((x) => x !== m.id) : [...contactMethods, m.id])}
-                        className="flex min-h-[80px] flex-col items-center justify-center gap-1.5 rounded-xl border px-2 py-3 text-sm font-semibold transition-colors"
-                        style={{ borderColor: sel ? TEAL : LINE, borderWidth: sel ? 2 : 1, background: sel ? `${TEAL}0D` : '#FFF', color: sel ? TEAL : INK }}>
+                        className={`flex min-h-[80px] flex-col items-center justify-center gap-1.5 rounded-xl border px-2 py-3 text-sm font-semibold transition-all ${sel ? 'border-[#84CC16] bg-[#F7FEE7] dark:bg-slate-900/60 ring-2 ring-[#84CC16] text-[#65A30D]' : 'border-slate-200 dark:border-slate-800 text-slate-700 dark:text-slate-200 hover:border-[#84CC16] hover:bg-slate-50 dark:hover:bg-slate-800'}`}>
                         <m.icon size={20} />
                         {m.label}
-                        <span className="text-[10px] font-normal" style={{ color: '#8A867B' }}>{m.hint}</span>
+                        <span className="text-[10px] font-normal text-slate-400">{m.hint}</span>
                       </button>
                     );
                   })}
@@ -660,12 +694,11 @@ export default function PostScreen({
 
                 {contactMethods.includes('whatsapp') && (
                   <div className="mt-4">
-                    <label className="block text-sm font-medium mb-1.5" style={{ color: INK }}>WhatsApp: ¿cómo te escriben?</label>
-                    <div className="inline-flex rounded-xl border p-1" style={{ borderColor: LINE, background: '#FFF' }}>
+                    <label className={labelClass}>WhatsApp: ¿cómo te escriben?</label>
+                    <div className="inline-flex rounded-xl border border-slate-200 dark:border-slate-700 p-1 bg-white dark:bg-slate-950">
                       {[{ id: 'phone', label: 'Número de teléfono' }, { id: 'username', label: 'Usuario (@usuario)' }].map((opt) => (
                         <button key={opt.id} type="button" onClick={() => setWaMode(opt.id)}
-                          className="min-h-[40px] rounded-lg px-4 text-sm font-semibold transition-colors"
-                          style={{ background: waMode === opt.id ? TEAL : 'transparent', color: waMode === opt.id ? '#FFF' : INK }}>
+                          className={`min-h-[40px] rounded-lg px-4 text-sm font-semibold transition-colors ${waMode === opt.id ? 'bg-[#84CC16] text-slate-950' : 'text-slate-600 dark:text-slate-300'}`}>
                           {opt.label}
                         </button>
                       ))}
@@ -675,88 +708,91 @@ export default function PostScreen({
 
                 <div className="mt-4 grid gap-4 md:grid-cols-2">
                   {(contactMethods.includes('phone') || (contactMethods.includes('whatsapp') && waMode === 'phone')) && (
-                    <Field label="Teléfono (10 dígitos)">
+                    <div>
+                      <label className={labelClass}>Teléfono (10 dígitos)</label>
                       <div className="relative">
-                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[15px]" style={{ color: '#8A867B' }}>+52</span>
+                        <span className="absolute left-3.5 top-1/2 -translate-y-1/2 font-medium text-slate-400 text-[14px]">+52</span>
                         <input type="tel" value={phoneValue} onChange={(e) => setPhoneValue(e.target.value.replace(/[^\d\s-]/g, ''))}
-                          placeholder="55 1234 5678" className={inputClass} style={{ borderColor: LINE, paddingLeft: '3rem' }} {...focusHandlers} />
+                          placeholder="55 1234 5678" className="w-full pl-11 pr-3.5 py-2.5 border border-slate-300 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white" />
                       </div>
                       {contactMethods.includes('whatsapp') && waMode === 'phone' && (
-                        <p className="mt-1 text-xs" style={{ color: '#8A867B' }}>Se usará también para WhatsApp</p>
+                        <p className="mt-1 text-xs text-slate-400">Se usará también para WhatsApp</p>
                       )}
-                    </Field>
+                    </div>
                   )}
                   {contactMethods.includes('whatsapp') && waMode === 'username' && (
-                    <Field label="Usuario de WhatsApp">
+                    <div>
+                      <label className={labelClass}>Usuario de WhatsApp</label>
                       <div className="relative">
-                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[15px]" style={{ color: '#8A867B' }}>@</span>
+                        <span className="absolute left-3.5 top-1/2 -translate-y-1/2 font-medium text-slate-400 text-[14px]">@</span>
                         <input value={waUsername} onChange={(e) => setWaUsername(e.target.value.replace(/^@/, ''))} placeholder="usuario"
-                          className={inputClass} style={{ borderColor: LINE, paddingLeft: '1.8rem' }} {...focusHandlers} />
+                          className="w-full pl-7 pr-3.5 py-2.5 border border-slate-300 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white" />
                       </div>
-                    </Field>
+                    </div>
                   )}
                   {contactMethods.includes('telegram') && (
-                    <Field label="Usuario de Telegram">
+                    <div>
+                      <label className={labelClass}>Usuario de Telegram</label>
                       <div className="relative">
-                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[15px]" style={{ color: '#8A867B' }}>@</span>
+                        <span className="absolute left-3.5 top-1/2 -translate-y-1/2 font-medium text-slate-400 text-[14px]">@</span>
                         <input value={telegramValue} onChange={(e) => setTelegramValue(e.target.value.replace(/^@/, ''))} placeholder="usuario"
-                          className={inputClass} style={{ borderColor: LINE, paddingLeft: '1.8rem' }} {...focusHandlers} />
+                          className="w-full pl-7 pr-3.5 py-2.5 border border-slate-300 dark:border-slate-700 rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] transition-all bg-white dark:bg-slate-950 text-slate-900 dark:text-white" />
                       </div>
-                    </Field>
+                    </div>
                   )}
                 </div>
               </div>
+
+              {/* Step 3 navigation */}
+              <div className="hidden md:flex justify-between items-center pt-6">
+                <button type="button" onClick={goBack} className="btn-lg border border-slate-200 text-slate-700 hover:bg-slate-50 flex items-center gap-1.5">
+                  <ChevronLeft size={16} /> Atrás
+                </button>
+                <button
+                  type="submit"
+                  disabled={postLoading || savingContact || !step3Valid}
+                  className="btn-lg bg-[#0F172A] text-white hover:bg-black flex items-center justify-center gap-2 disabled:opacity-50"
+                >
+                  {(postLoading || savingContact)
+                    ? <Loader2 className="animate-spin" size={20} />
+                    : <><Sparkles size={18} /> {editingAd ? t.save_changes || 'Guardar cambios' : t.publish_btn}</>
+                  }
+                </button>
+              </div>
+
             </div>
           )}
 
-          {/* NAV (desktop) */}
-          <div className="hidden md:flex gap-3 justify-between pt-4">
-            {step > 1 ? (
-              <button type="button" onClick={goBack} className="flex min-h-[50px] items-center justify-center gap-1.5 rounded-xl border px-6 text-[15px] font-semibold"
-                style={{ borderColor: LINE, color: INK, background: '#FFF' }}>
-                <ChevronLeft size={18} /> Atrás
-              </button>
-            ) : <div />}
-            {step < 3 ? (
-              <button type="button" onClick={goNext}
-                className="flex min-h-[50px] items-center justify-center gap-1.5 rounded-xl px-8 text-[15px] font-semibold text-white"
-                style={{ background: TEAL }}>
-                Siguiente <ChevronRight size={18} />
-              </button>
-            ) : (
-              <button type="submit" disabled={postLoading || savingContact || !step3Valid}
-                className="flex min-h-[50px] items-center justify-center gap-2 rounded-xl px-8 text-[15px] font-semibold text-white disabled:opacity-50"
-                style={{ background: PINK }}>
-                {(postLoading || savingContact)
-                  ? <Loader2 className="animate-spin" size={20} />
-                  : <><Sparkles size={18} /> {editingAd ? (t.save_changes || 'Guardar cambios') : t.publish_btn}</>}
-              </button>
-            )}
-          </div>
         </form>
-      </main>
+      </div>
 
-      {/* NAV (mobile sticky) */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 flex gap-3 border-t bg-white px-4 py-3 md:hidden" style={{ borderColor: LINE }}>
+      {/* Mobile sticky navigation */}
+      <div className="fixed bottom-0 inset-x-0 z-40 flex gap-3 border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-4 py-3 md:hidden">
         {step > 1 ? (
-          <button type="button" onClick={goBack} className="flex min-h-[50px] flex-1 items-center justify-center gap-1.5 rounded-xl border px-4 text-[15px] font-semibold"
-            style={{ borderColor: LINE, color: INK, background: '#FFF' }}>
-            <ChevronLeft size={18} /> Atrás
+          <button type="button" onClick={goBack} className="btn-lg border border-slate-200 text-slate-700 hover:bg-slate-50 flex-1 flex items-center justify-center gap-1.5">
+            <ChevronLeft size={16} /> Atrás
           </button>
         ) : <div className="flex-1" />}
         {step < 3 ? (
-          <button type="button" onClick={goNext}
-            className="flex min-h-[50px] flex-[2] items-center justify-center gap-1.5 rounded-xl px-8 text-[15px] font-semibold text-white"
-            style={{ background: TEAL }}>
-            Siguiente <ChevronRight size={18} />
+          <button
+            type="button"
+            disabled={step === 1 && (!form.category || ((subcategoriesMap[form.category] || []).length > 0 && !form.subcategory))}
+            onClick={goNext}
+            className="btn-lg bg-[#0F172A] text-white hover:bg-black flex-[2] flex items-center justify-center gap-1.5 disabled:opacity-50"
+          >
+            Siguiente <ChevronRight size={16} />
           </button>
         ) : (
-          <button type="button" onClick={handleFinalSubmit} disabled={postLoading || savingContact || !step3Valid}
-            className="flex min-h-[50px] flex-[2] items-center justify-center gap-2 rounded-xl px-8 text-[15px] font-semibold text-white disabled:opacity-50"
-            style={{ background: PINK }}>
+          <button
+            type="button"
+            onClick={handleFinalSubmit}
+            disabled={postLoading || savingContact || !step3Valid}
+            className="btn-lg bg-[#0F172A] text-white hover:bg-black flex-[2] flex items-center justify-center gap-2 disabled:opacity-50"
+          >
             {(postLoading || savingContact)
               ? <Loader2 className="animate-spin" size={20} />
-              : <><Sparkles size={18} /> {editingAd ? (t.save_changes || 'Guardar cambios') : t.publish_btn}</>}
+              : <><Sparkles size={18} /> {editingAd ? t.save_changes || 'Guardar cambios' : t.publish_btn}</>
+            }
           </button>
         )}
       </div>


### PR DESCRIPTION
Replaces the prototype's off-brand palette (serif headings, teal/pink) with the site's actual Tailwind/CSS-variable design system: Inter everywhere, lime #84CC16/#65A30D accents, slate-200/300/700/800 borders, rounded-xl cards, and full dark-mode support — matching EditAdScreen and the rest of the app pixel-for-pixel. No functional change from the previous commit: still 3 steps (Categoría/Detalles/ Contacto), still preserves the current main PostScreen's sale facets, API-only dynamic attributes, noValidate, and MapV3 onLocationSelect API.

## Summary

-

## Agent owner

-

## Risk level

- [ ] Low: docs/copy/non-runtime
- [ ] Medium: UI/backend behavior but no sensitive areas
- [ ] High: auth/payments/uploads/database/infra/security
- [ ] Critical: production/secrets/destructive operations

## Two-step critique

### Critique 1: risk and correctness

-

### Critique 2: alternatives and quality

-

## Changed areas

- [ ] Frontend
- [ ] Backend/API
- [ ] Database
- [ ] Docker/infra
- [ ] Security/auth
- [ ] Payments/Clip
- [ ] AI/ML
- [ ] SEO/content
- [ ] Documentation only

## Smoke tests

-

## Rollback plan

-

## Human approval needed?

- [ ] No
- [ ] Yes — auth, payments, secrets, database destructive changes, Docker networking, DNS, production deploy, or legal/policy changes

## Screenshots / evidence

-
