### PR TITLE
fix: exclude .claude/worktrees from Docker build context (blocks all deploys)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .github
 .gitignore
+.claude/worktrees
 .env
 .env.*
 *.pem


### PR DESCRIPTION
## Summary
`deploy-selfhosted.yml` builds Docker images with build context = `/var/www/mercasto`, which also contains sibling Claude Code session worktrees under `.claude/worktrees/`. `.dockerignore` never excluded that path.

Run [28717712767](https://github.com/johnslimg-alt/mercasto/actions/runs/28717712767) (triggered by PR #315, an unrelated static-asset PR) failed the entire deploy because a different, concurrent worktree (`focused-elbakyan-956c42`) had a `backend/storage/framework/testing/disks` directory with restrictive `0700` permissions left over from a test run — Docker's build-context tar couldn't read it, so the whole build-context transfer failed:
```
error from sender: open /var/www/mercasto/.claude/worktrees/focused-elbakyan-956c42/backend/storage/framework/testing/disks: permission denied
```
This isn't specific to that one file — any future permission hiccup in any concurrent session's worktree will reproduce the same full-deploy failure, unrelated to whatever the triggering PR actually changed. The recovery step already restored the previous containers (production wasn't down), but the new deploy (banners from PR #315) never went live.

## Fix
Added `.claude/worktrees` to `.dockerignore`. Those checkouts have no reason to be inside a production build context regardless of this specific incident — this also shrinks the build-context size.

## Risk
Very low. One-line `.dockerignore` addition, no app code touched.

## Smoke
- Can't fully reproduce the multi-worktree scenario in CI, but the fix is a standard `.dockerignore` exclusion pattern — verified the path matches the actual directory structure (`/var/www/mercasto/.claude/worktrees/*`).

## Rollback
Revert the commit.