### PR TITLE
fix: stop Turismo posting flow from submitting invalid categories

### DIFF
--- a/src/components/screens/PostScreen.jsx
+++ b/src/components/screens/PostScreen.jsx
@@ -35,18 +35,6 @@ const PRODUCT_GROUPS = [
   { slug: 'formacion', label: { es: 'Libros y Cursos', en: 'Books & Courses', ru: 'Книги и курсы' } },
 ];
 
-const TURISMO_GROUPS = [
-  { slug: 'hospedaje', label: { es: 'Hoteles y Hospedaje', en: 'Hotels & Lodging', ru: 'Отели и жилье' } },
-  { slug: 'tours', label: { es: 'Tours y Viajes', en: 'Tours & Trips', ru: 'Туры и путешествия' } },
-  { slug: 'boletos_turismo', label: { es: 'Boletos a Eventos', en: 'Event Tickets', ru: 'Билеты на мероприятия' } },
-  { slug: 'articulos_camping', label: { es: 'Artículos de Viaje', en: 'Travel & Outdoor Gear', ru: 'Товары для туризма' } },
-  { slug: 'souvenirs', label: { es: 'Souvenirs y Regalos', en: 'Souvenirs & Gifts', ru: 'Сувениры и подарки' } },
-  { slug: 'renta_vehiculos', label: { es: 'Renta de Vehículos y Yates', en: 'Vehicle & Yacht Rental', ru: 'Аренда транспорта и яхт' } },
-  { slug: 'guias_servicios', label: { es: 'Guías y Servicios', en: 'Guides & Services', ru: 'Гиды и услуги' } },
-  { slug: 'atracciones_exp', label: { es: 'Atracciones y Experiencias', en: 'Attractions & Experiences', ru: 'Развлечения и впечатления' } },
-  { slug: 'retiros_bienestar', label: { es: 'Retiros y Bienestar', en: 'Retreats & Wellness', ru: 'Ретриты и велнес' } },
-];
-
 // Фасеты публикации — сохраняются в form.attributes (filterConfig) и используются фильтрами поиска
 // (доставки нет: продажа напрямую покупатель↔продавец).
 const SALE_FACETS = [
@@ -142,21 +130,12 @@ export default function PostScreen({
       infantil: 'productos',
       mascotas: 'productos',
       formacion: 'productos',
-      hospedaje: 'turismo',
-      tours: 'turismo',
-      boletos_turismo: 'turismo',
-      articulos_camping: 'turismo',
-      souvenirs: 'turismo',
-      renta_vehiculos: 'turismo',
-      guias_servicios: 'turismo',
-      atracciones_exp: 'turismo',
-      retiros_bienestar: 'turismo',
     };
     return parentMap[form.category] || '';
   });
 
   const handleParentCategorySelect = (slug) => {
-    if (slug === 'productos' || slug === 'turismo') {
+    if (slug === 'productos') {
       setSelectedParentCategory(slug);
       setForm({ ...form, category: '', subcategory: '', attributes: {} });
     } else {
@@ -448,29 +427,6 @@ export default function PostScreen({
                 </div>
               )}
 
-              {/* TURISMO GROUPS (Level 2 for Tourism) */}
-              {selectedParentCategory === 'turismo' && (
-                <div className="animate-in fade-in slide-in-from-top-4 duration-300">
-                  <label className="block text-[14px] font-bold text-slate-700 dark:text-slate-300 mb-3">
-                    {lang === 'es' ? 'Selecciona el Tipo de Servicio Turístico' : 'Select Tourism Type'}
-                  </label>
-                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    {TURISMO_GROUPS.map(group => {
-                      const selected = form.category === group.slug;
-                      return (
-                        <button
-                          key={group.slug}
-                          type="button"
-                          onClick={() => handleProductGroupSelect(group.slug)}
-                          className={`p-3 rounded-lg border text-center transition-all text-xs font-semibold ${selected ? 'border-[#84CC16] bg-[#F7FEE7] dark:bg-slate-900/60 ring-2 ring-[#84CC16]' : 'border-slate-200 dark:border-slate-800 hover:border-[#84CC16] hover:bg-slate-50 dark:hover:bg-slate-800'}`}
-                        >
-                          {group.label[lang] || group.label.es}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
 
               {/* SUBCATEGORY (Level 3) */}
               {form.category && (subcategoriesMap[form.category] || []).length > 0 && (


### PR DESCRIPTION
The "Turismo" parent-category grouping in PostScreen (added after our 3-step form work) had a level-2 sub-menu (TURISMO_GROUPS) whose 9 options each overwrote form.category with invented slugs — hospedaje, tours, boletos_turismo, articulos_camping, souvenirs, renta_vehiculos, guias_servicios, atracciones_exp, retiros_bienestar. None of these exist as rows in the categories table, and ad creation validates 'category' => 'exists:categories,slug'. Result: picking any Turismo sub-option and completing the whole 3-step form always failed at the final submit with a validation error — a live, unrecoverable dead end.

Fix: route "Turismo" the same way every other real category already works — form.category stays 'turismo' (a real category), and the existing generic subcategory picker takes over immediately, reading subcategoriesMap['turismo'] from locationsAndCategories.js, which already lists these same 9 names as free-text subcategories (no DB constraint on subcategory). Removed the now-dead TURISMO_GROUPS constant, its JSX block, and the stale parent-category mapping. "Productos" grouping (Electrónica/Hogar/Moda/...) is untouched — its sub-options were already real top-level categories.

## Summary

-

## Agent owner

-

## Risk level

- [ ] Low: docs/copy/non-runtime
- [ ] Medium: UI/backend behavior but no sensitive areas
- [ ] High: auth/payments/uploads/database/infra/security
- [ ] Critical: production/secrets/destructive operations

## Two-step critique

### Critique 1: risk and correctness

-

### Critique 2: alternatives and quality

-

## Changed areas

- [ ] Frontend
- [ ] Backend/API
- [ ] Database
- [ ] Docker/infra
- [ ] Security/auth
- [ ] Payments/Clip
- [ ] AI/ML
- [ ] SEO/content
- [ ] Documentation only

## Smoke tests

-

## Rollback plan

-

## Human approval needed?

- [ ] No
- [ ] Yes — auth, payments, secrets, database destructive changes, Docker networking, DNS, production deploy, or legal/policy changes

## Screenshots / evidence

-
