### PR TITLE
fix: PostAd never fires (missing listing_id) + CompleteRegistration EMQ stuck at ip/ua-only

### DIFF
--- a/backend/app/Http/Controllers/Api/MetaEventController.php
+++ b/backend/app/Http/Controllers/Api/MetaEventController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use App\Services\MetaCapiService;
 use Illuminate\Http\Request;
 
@@ -28,12 +29,19 @@ class MetaEventController extends Controller
         $validated = $request->validate([
             'event_id' => ['required', 'string', 'max:120'],
             'url' => ['nullable', 'url'],
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
         ]);
+
+        // This endpoint fires right after signup, before the client necessarily has
+        // an authenticated session wired up, so we can't rely on $request->user().
+        // The frontend passes the newly created user's id instead; we look it up
+        // ourselves rather than trusting any client-supplied PII directly.
+        $user = isset($validated['user_id']) ? User::find($validated['user_id']) : null;
 
         $result = $meta->send(
             'CompleteRegistration',
             $request,
-            $request->user(),
+            $user,
             [],
             $validated['event_id'],
             $validated['url'] ?? null

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2643,6 +2643,8 @@ function App() {
       });
 
       if (res.ok) {
+        const savedAd = await res.json().catch(() => null);
+
         // Очищаем оперативную память браузера от временных файлов (Memory Leak fix)
         images.forEach(img => {
           if (img.source === 'new' && img.preview) {
@@ -2657,8 +2659,8 @@ function App() {
         setEditingAd(null);
         setCurrentTab('profile');
         navigate('/profile');
-        // GA4 ad posted event
-        if (!editingAd) events.adPosted(form.category || "general");
+        // GA4 + Meta Pixel/CAPI ad posted event
+        if (!editingAd && savedAd?.id) events.adPosted(savedAd.id, form.category || "general");
         loadAds(1); // Reload after create/update
         loadUserAds(); // Обновляем список моих объявлений
       } else {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -96,7 +96,7 @@ export function AuthProvider({ children }) {
         setUser(data.user);
         setShowAuthModal(false);
         localStorage.setItem('just_registered', '1');
-        events.registered();
+        events.registered({ user_id: data.user?.id });
         return { success: true };
       }
       

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -782,8 +782,8 @@ export const events = {
   adImpression: (adId, category, placement = 'feed') =>
     trackEvent('ad_impression', { content_type: 'ad', content_id: `ad_${adId}`, ad_id: adId, category, placement }),
 
-  adPosted: (category, params = {}) =>
-    trackEvent('ad_posted', { content_type: 'ad', category, ...params }),
+  adPosted: (adId, category, params = {}) =>
+    trackEvent('ad_posted', { content_type: 'ad', content_id: `ad_${adId}`, ad_id: adId, category, ...params }),
 
   adUpdated: (adId, category, params = {}) =>
     trackEvent('ad_updated', { content_type: 'ad', content_id: `ad_${adId}`, ad_id: adId, category, ...params }),

--- a/src/utils/metaCapiBridge.js
+++ b/src/utils/metaCapiBridge.js
@@ -55,6 +55,7 @@ function buildPayload(dataLayerItem = {}) {
     category: clean(dataLayerItem.category || dataLayerItem.content_category || ''),
     city: clean(dataLayerItem.city || dataLayerItem.location_city || ''),
     url: clean(dataLayerItem.page_location || window.location.href),
+    user_id: clean(dataLayerItem.user_id || ''),
   };
 }
 


### PR DESCRIPTION
## Summary
User audited Meta Events Manager (Pixel `4595315270748335`) directly and found two real bugs the earlier PostAd fix (#312) didn't catch:

**1. PostAd still never appears (neither browser nor server) — root cause found:**
- `events.adPosted()` in `analytics.js` took no ad/listing id argument at all, unlike every sibling event (`adViewed`, `adImpression`, `adUpdated`) which all pass one. `App.jsx`'s publish-success handler called it with just a category string.
- `metaCapiBridge.js`'s `sendMappedEvent()` has a guard — `if (!isReg && !payload.listing_id) return;` — that silently drops any non-registration event with no listing id. Every `PostAd` call hit this guard and returned before reaching either the browser Pixel or the server CAPI call. This is the actual reason nothing ever showed up — not a Meta-side delay.
- Fix: `App.jsx` now parses the ad-creation response body (backend already returns the new ad, including `id`, at 201) and passes `savedAd.id` through to `events.adPosted(savedAd.id, category)`.

**2. CompleteRegistration Event Match Quality stuck at 3/10 (only ip_address/user_agent matching, no email/phone/external_id) — root cause found:**
- `/api/meta/events/register` is intentionally unauthenticated (it fires right after signup, before any session is wired up), so `MetaEventController::register()` calling `$request->user()` always returned `null` — `MetaCapiService::userData()` had nothing to hash.
- `metaCapiBridge.js`'s `buildPayload()` never included any user identifier for any event type in the first place.
- Fix: `AuthContext.jsx`'s `register()` now passes the newly created user's id through `events.registered({ user_id })` → `buildPayload()` → the register CAPI request body. `MetaEventController::register()` looks that specific user up server-side (doesn't trust client-supplied PII directly, just an id) to build the hashed `em`/`ph`/`external_id` fields.

## Risk
Low-medium. Frontend: two call-site fixes, no behavior change for other events. Backend: one new optional, validated (`exists:users,id`) field on an already-unauthenticated endpoint; no auth/security boundary changes — this is analytics attribution, not access control.

## Smoke
- `npm run lint:ci` — 0 errors.
- `npm run build` — succeeds.
- `php -l` on the touched controller — no syntax errors.
- Not yet verified live: needs a real ad publish + real registration on production, then a check in Meta Events Manager for (a) PostAd appearing browser+server with matching event_id, (b) CompleteRegistration EMQ improving beyond ip/ua.

## Rollback
Revert this commit — reverts to the PR #312/#313 state (registration CAPI still fires but with poor match quality; PostAd still silently dropped).