### PR TITLE
fix: make subcategory search filter actually filter, align turismo po…

### DIFF
--- a/backend/app/Http/Controllers/Api/AdIndexController.php
+++ b/backend/app/Http/Controllers/Api/AdIndexController.php
@@ -49,6 +49,10 @@ class AdIndexController extends Controller
             $query->where('category', $request->category);
         }
 
+        if ($request->filled('subcategory')) {
+            $query->whereRaw('subcategory ILIKE ?', [(string) $request->subcategory]);
+        }
+
         if ($request->filled('search')) {
             $search = (string) $request->search;
 
@@ -170,6 +174,7 @@ class AdIndexController extends Controller
             'radius',
             'user_id',
             'category',
+            'subcategory',
             'search',
             'location',
             'city',

--- a/src/components/screens/PostScreen.jsx
+++ b/src/components/screens/PostScreen.jsx
@@ -8,8 +8,21 @@ import {
 } from 'lucide-react';
 import { mexicoLocations, subcategoriesMap } from '../../constants/locationsAndCategories';
 import { filterConfig } from '../../constants/filterConfig';
+import { subcategoriesByLang } from '../../constants/subcategoryTranslations';
 import MapV3 from '../common/MapV3';
 import SortablePhotoGrid from '../SortablePhotoGrid';
+
+// Mirrors App.jsx's getSubcategoryOptions: some categories (currently only "turismo") store a
+// stable slug as the subcategory value (matching real listing data + the search filter dropdown),
+// while the rest store the canonical Spanish label text as-is. Always posts in Spanish, since ad
+// content itself is not translated per-poster-language.
+function getPostSubcategoryOptions(category) {
+  const bySlug = subcategoriesByLang.es[category];
+  if (bySlug && !Array.isArray(bySlug)) {
+    return Object.keys(bySlug).map((slug) => ({ value: slug, label: bySlug[slug] }));
+  }
+  return (subcategoriesMap[category] || []).map((label) => ({ value: label, label }));
+}
 
 const API_URL = import.meta.env.VITE_API_BASE_URL || 'https://mercasto.com/api';
 
@@ -230,7 +243,7 @@ export default function PostScreen({
   const goNext = () => {
     if (step === 1) {
       if (!form.category) { alert('Selecciona una categoría.'); return; }
-      const subs = subcategoriesMap[form.category] || [];
+      const subs = getPostSubcategoryOptions(form.category);
       if (subs.length > 0 && !form.subcategory) { alert('Selecciona una subcategoría.'); return; }
       setStep(2);
       window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -429,20 +442,20 @@ export default function PostScreen({
 
 
               {/* SUBCATEGORY (Level 3) */}
-              {form.category && (subcategoriesMap[form.category] || []).length > 0 && (
+              {form.category && getPostSubcategoryOptions(form.category).length > 0 && (
                 <div className="mt-4 animate-in fade-in slide-in-from-top-4 duration-300">
                   <label className="block text-[14px] font-bold text-slate-700 dark:text-slate-300 mb-3">
                     Selecciona una Subcategoría
                   </label>
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    {(subcategoriesMap[form.category] || []).map(sub => (
+                    {getPostSubcategoryOptions(form.category).map(({ value, label }) => (
                       <button
-                        key={sub}
+                        key={value}
                         type="button"
-                        onClick={() => setForm({ ...form, subcategory: sub })}
-                        className={`p-3 rounded-lg border text-center transition-all text-xs font-semibold ${form.subcategory === sub ? 'border-[#84CC16] bg-[#F7FEE7] dark:bg-slate-900/60 ring-2 ring-[#84CC16]' : 'border-slate-200 dark:border-slate-800 hover:border-[#84CC16] hover:bg-slate-50 dark:hover:bg-slate-800'}`}
+                        onClick={() => setForm({ ...form, subcategory: value })}
+                        className={`p-3 rounded-lg border text-center transition-all text-xs font-semibold ${form.subcategory === value ? 'border-[#84CC16] bg-[#F7FEE7] dark:bg-slate-900/60 ring-2 ring-[#84CC16]' : 'border-slate-200 dark:border-slate-800 hover:border-[#84CC16] hover:bg-slate-50 dark:hover:bg-slate-800'}`}
                       >
-                        {sub}
+                        {label}
                       </button>
                     ))}
                   </div>
@@ -452,7 +465,7 @@ export default function PostScreen({
               <div className="hidden md:flex justify-end pt-6">
                 <button
                   type="button"
-                  disabled={!form.category || ((subcategoriesMap[form.category] || []).length > 0 && !form.subcategory)}
+                  disabled={!form.category || (getPostSubcategoryOptions(form.category).length > 0 && !form.subcategory)}
                   onClick={goNext}
                   className="btn-lg bg-[#0F172A] text-white hover:bg-black flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
@@ -861,7 +874,7 @@ export default function PostScreen({
         {step < 3 ? (
           <button
             type="button"
-            disabled={step === 1 && (!form.category || ((subcategoriesMap[form.category] || []).length > 0 && !form.subcategory))}
+            disabled={step === 1 && (!form.category || (getPostSubcategoryOptions(form.category).length > 0 && !form.subcategory))}
             onClick={goNext}
             className="btn-lg bg-[#0F172A] text-white hover:bg-black flex-[2] flex items-center justify-center gap-1.5 disabled:opacity-50"
           >


### PR DESCRIPTION
…sting with real taxonomy

Audit of category/attribute/filter sync across the form, search, and map found:

- AdIndexController::index (the real controller behind the public GET /api/ads endpoint) never read the `subcategory` query param. App.jsx's subcategory dropdown has sent it correctly all along, but selecting any subcategory silently returned the same unfiltered results for every category on the site — verified live (Motor → Motos stayed at 16/16 results, garbage values did too). Added the same ILIKE filter pattern already used for other fields, plus `subcategory` to the cache-bypass anyFilled() list.

- PostScreen's turismo posting flow still let sellers pick from the old flat 9-label taxonomy and stored the Spanish label text as `subcategory`. A separate, already-merged fix (feat/subcategory-i18n, based on auditing real listing data) moved the *search* dropdown to the real 16-slug taxonomy (hospedaje, renta_autos, renta_motos, ...) that live turismo ads actually use — but nothing updated the posting form to match, so newly-created turismo ads would still be unfindable by subcategory. Added getPostSubcategoryOptions() mirroring App.jsx's getSubcategoryOptions(): turismo now posts the same slugs the search filter (and real data) already use; every other category is unchanged (still posts the canonical label text, matching its search dropdown).

No changes needed elsewhere — categories, category-attributes API, sale facets, and location/price/condition filters were all already correctly wired end to end (verified via live API + browser testing against production, not just source reading).

## Summary

-

## Agent owner

-

## Risk level

- [ ] Low: docs/copy/non-runtime
- [ ] Medium: UI/backend behavior but no sensitive areas
- [ ] High: auth/payments/uploads/database/infra/security
- [ ] Critical: production/secrets/destructive operations

## Two-step critique

### Critique 1: risk and correctness

-

### Critique 2: alternatives and quality

-

## Changed areas

- [ ] Frontend
- [ ] Backend/API
- [ ] Database
- [ ] Docker/infra
- [ ] Security/auth
- [ ] Payments/Clip
- [ ] AI/ML
- [ ] SEO/content
- [ ] Documentation only

## Smoke tests

-

## Rollback plan

-

## Human approval needed?

- [ ] No
- [ ] Yes — auth, payments, secrets, database destructive changes, Docker networking, DNS, production deploy, or legal/policy changes

## Screenshots / evidence

-
