### PR TITLE
fix: remove dead SendMetaCapiEventJob dispatch (throws on every ad publish)

### DIFF
--- a/backend/app/Http/Controllers/Api/AdController.php
+++ b/backend/app/Http/Controllers/Api/AdController.php
@@ -569,27 +569,9 @@ class AdController extends Controller
             ProcessVideoWatermark::dispatch($ad);
         }
 
-        // Dispatch Meta Conversions API (CAPI) tracking event
-        try {
-            $adUser = $request->user();
-            $customData = [
-                'content_name' => $ad->title,
-                'content_category' => $ad->category,
-                'content_ids' => [(string) $ad->id],
-                'value' => (float) $ad->price,
-                'currency' => 'MXN',
-            ];
-            \App\Jobs\SendMetaCapiEventJob::dispatch(
-                'SubmitApplication', // Standard event name for submitting forms/ads
-                $adUser->email,
-                $adUser->phone_number ?? $adUser->whatsapp,
-                $request->ip(),
-                $request->userAgent(),
-                $customData
-            );
-        } catch (\Throwable $e) {
-            \Log::warning('Meta CAPI Dispatch Error: ' . $e->getMessage());
-        }
+        // Meta CAPI PostAd tracking is handled by the frontend bridge (metaCapiBridge.js ->
+        // /api/meta/events/post-ad) using the same event_id as the browser Pixel call, so it
+        // dedupes correctly. This controller intentionally does not send its own CAPI event.
 
         // --- AI СИСТЕМА: СЕМАНТИЧЕСКИЙ ПОИСК (EMBEDDINGS) И АВТО-МОДЕРАЦИЯ ---
         dispatch(function () use ($ad) {


### PR DESCRIPTION
## Summary
While verifying PR #318 by simulating both CAPI flows directly against the backend, found that `AdController@store` still calls `\App\Jobs\SendMetaCapiEventJob::dispatch(...)` — but that Job class does not exist on the server. Every single ad publish silently throws, gets caught by the surrounding try/catch, and logs a `Meta CAPI Dispatch Error` warning. Pure log noise; no functional effect either way since the exception fires before any real work happens.

It was also using the wrong standard event name (`SubmitApplication`) from an older, since-abandoned tracking scheme. Real `PostAd` tracking is fully owned by the frontend bridge (`metaCapiBridge.js` → `POST /api/meta/events/post-ad`), and was confirmed end-to-end working via direct backend simulation (Meta Graph API returned `status 200`, `events_received: 1`). Keeping this block would only risk a future duplicate send, not add anything.

## Risk
Very low. Removes 21 lines that have never executed successfully (the referenced class doesn't exist); no behavior change for any working code path.

## Smoke
- `php -l` — no syntax errors.
- Confirmed via backend simulation (tinker) that the real `PostAd` CAPI path (`MetaEventController::postAd`) works independently of this removed block.

## Rollback
Revert the commit.