### PR TITLE
feat: broaden Motor brands/models across NA, Europe, Asia; add buses …

### DIFF
--- a/backend/database/migrations/2026_07_04_000002_expand_motor_marca_options.php
+++ b/backend/database/migrations/2026_07_04_000002_expand_motor_marca_options.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    private const NEW_OPTIONS = [
+        'Chevrolet', 'Ford', 'RAM', 'Dodge', 'Jeep', 'Chrysler', 'GMC', 'Cadillac', 'Buick', 'Lincoln', 'Tesla',
+        'Toyota', 'Honda', 'Nissan', 'Mazda', 'Mitsubishi', 'Suzuki', 'Subaru', 'Lexus', 'Acura', 'Infiniti', 'Isuzu', 'Kia', 'Hyundai', 'Genesis',
+        'Volkswagen', 'BMW', 'Mercedes-Benz', 'Audi', 'Porsche', 'MINI', 'Smart',
+        'SEAT', 'Renault', 'Peugeot', 'Citroën', 'Fiat', 'Alfa Romeo', 'Volvo', 'Land Rover', 'Jaguar',
+        'BYD', 'MG', 'Chirey', 'JAC', 'GWM (Haval)', 'Changan', 'Omoda/Jaecoo', 'DFSK', 'Foton',
+        'Scania', 'International', 'Freightliner', 'MAN', 'Iveco', 'Dina', 'Hino',
+        'Otra',
+    ];
+
+    private const OLD_OPTIONS = ['Nissan', 'Toyota', 'Honda', 'Volkswagen', 'Chevrolet', 'Ford', 'Otra'];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $categoryId = DB::table('categories')->where('slug', 'motor')->value('id');
+
+        if (! $categoryId) {
+            return;
+        }
+
+        DB::table('category_attributes')
+            ->where('category_id', $categoryId)
+            ->where('key', 'marca')
+            ->update([
+                'options' => json_encode(self::NEW_OPTIONS),
+                'updated_at' => now(),
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $categoryId = DB::table('categories')->where('slug', 'motor')->value('id');
+
+        if (! $categoryId) {
+            return;
+        }
+
+        DB::table('category_attributes')
+            ->where('category_id', $categoryId)
+            ->where('key', 'marca')
+            ->update([
+                'options' => json_encode(self::OLD_OPTIONS),
+                'updated_at' => now(),
+            ]);
+    }
+};

--- a/backend/database/seeders/CategoryAttributeSeeder.php
+++ b/backend/database/seeders/CategoryAttributeSeeder.php
@@ -194,7 +194,15 @@ class CategoryAttributeSeeder extends Seeder
 
         $catalog = [
             'motor' => [
-                ['marca', 'Marca', 'select', ['Nissan', 'Toyota', 'Honda', 'Volkswagen', 'Chevrolet', 'Ford', 'Otra']],
+                ['marca', 'Marca', 'select', [
+                    'Chevrolet', 'Ford', 'RAM', 'Dodge', 'Jeep', 'Chrysler', 'GMC', 'Cadillac', 'Buick', 'Lincoln', 'Tesla',
+                    'Toyota', 'Honda', 'Nissan', 'Mazda', 'Mitsubishi', 'Suzuki', 'Subaru', 'Lexus', 'Acura', 'Infiniti', 'Isuzu', 'Kia', 'Hyundai', 'Genesis',
+                    'Volkswagen', 'BMW', 'Mercedes-Benz', 'Audi', 'Porsche', 'MINI', 'Smart',
+                    'SEAT', 'Renault', 'Peugeot', 'Citroën', 'Fiat', 'Alfa Romeo', 'Volvo', 'Land Rover', 'Jaguar',
+                    'BYD', 'MG', 'Chirey', 'JAC', 'GWM (Haval)', 'Changan', 'Omoda/Jaecoo', 'DFSK', 'Foton',
+                    'Scania', 'International', 'Freightliner', 'MAN', 'Iveco', 'Dina', 'Hino',
+                    'Otra',
+                ]],
                 ['modelo', 'Modelo', 'text', null],
                 ['year', 'Año', 'number', null],
                 ['km', 'Kilometraje', 'number', null],

--- a/src/components/screens/PostScreen.jsx
+++ b/src/components/screens/PostScreen.jsx
@@ -7,7 +7,7 @@ import {
   Phone, MessageCircle, Send, Locate, Compass,
 } from 'lucide-react';
 import { mexicoLocations, subcategoriesMap } from '../../constants/locationsAndCategories';
-import { filterConfig } from '../../constants/filterConfig';
+import { filterConfig, autoModelsByBrand } from '../../constants/filterConfig';
 import { subcategoriesByLang } from '../../constants/subcategoryTranslations';
 import MapV3 from '../common/MapV3';
 import SortablePhotoGrid from '../SortablePhotoGrid';
@@ -326,6 +326,35 @@ export default function PostScreen({
     const hasErr = !!errors[errKey];
     const baseClass = `w-full px-3.5 py-2.5 border ${hasErr ? 'border-red-400' : 'border-slate-300 dark:border-slate-700'} rounded-xl outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-[14px] bg-white dark:bg-slate-950 text-slate-900 dark:text-white transition-all`;
     const onChange = v => setForm(prev => ({ ...prev, attributes: { ...(prev.attributes || {}), [key]: v } }));
+
+    if (key === 'modelo') {
+      const selectedBrand = form.attributes?.marca || '';
+      const models = autoModelsByBrand[selectedBrand];
+      if (models?.length > 0) {
+        return (
+          <div key={key} className="space-y-2">
+            <label className="block text-[13px] font-semibold text-slate-700 dark:text-slate-300">
+              {field.label || key}{field.required && <span className="text-red-500 ml-1">*</span>}
+            </label>
+            <select value={val} onChange={e => onChange(e.target.value)} className={baseClass + ' cursor-pointer'}>
+              <option value="">Seleccionar...</option>
+              {models.map(m => <option key={m} value={m}>{m}</option>)}
+              <option value="Otro">Otro modelo</option>
+            </select>
+            {val === 'Otro' && (
+              <input
+                type="text"
+                value={form.attributes?.modelo_otro || ''}
+                onChange={e => setForm(prev => ({ ...prev, attributes: { ...(prev.attributes || {}), modelo_otro: e.target.value, modelo: e.target.value } }))}
+                placeholder="Especifica el modelo"
+                className={baseClass + ' mt-2'}
+              />
+            )}
+            {hasErr && <p className="text-xs text-red-500">{errors[errKey]}</p>}
+          </div>
+        );
+      }
+    }
 
     if (field.type === 'select' && field.options?.length > 0) {
       return (

--- a/src/constants/filterConfig.js
+++ b/src/constants/filterConfig.js
@@ -1,7 +1,81 @@
 const autoBrands = [
-  'Chevrolet', 'Nissan', 'Volkswagen', 'Toyota', 'Honda', 'Ford', 'BMW', 'Mercedes-Benz',
-  'Audi', 'Kia', 'Hyundai', 'Mazda', 'Jeep', 'Tesla', 'MG', 'BYD', 'Otra'
+  // Norteamérica
+  'Chevrolet', 'Ford', 'RAM', 'Dodge', 'Jeep', 'Chrysler', 'GMC', 'Cadillac', 'Buick', 'Lincoln', 'Tesla',
+  // Japón / Corea
+  'Toyota', 'Honda', 'Nissan', 'Mazda', 'Mitsubishi', 'Suzuki', 'Subaru', 'Lexus', 'Acura', 'Infiniti', 'Isuzu', 'Kia', 'Hyundai', 'Genesis',
+  // Alemania
+  'Volkswagen', 'BMW', 'Mercedes-Benz', 'Audi', 'Porsche', 'MINI', 'Smart',
+  // Europa (otros)
+  'SEAT', 'Renault', 'Peugeot', 'Citroën', 'Fiat', 'Alfa Romeo', 'Volvo', 'Land Rover', 'Jaguar',
+  // China
+  'BYD', 'MG', 'Chirey', 'JAC', 'GWM (Haval)', 'Changan', 'Omoda/Jaecoo', 'DFSK', 'Foton',
+  // Camiones y autobuses comerciales
+  'Scania', 'International', 'Freightliner', 'MAN', 'Iveco', 'Dina', 'Hino',
+  'Otra'
 ];
+
+// Modelos reales más comunes por marca en el mercado mexicano.
+// Se usa para el select dependiente Marca -> Modelo al publicar; marcas sin
+// entrada aquí (o "Otra") caen a un campo de texto libre.
+export const autoModelsByBrand = {
+  'Chevrolet': ['Aveo', 'Onix', 'Silverado', 'Equinox', 'Tracker', 'Captiva', 'Cavalier', 'Suburban', 'Spark', 'Blazer', 'Colorado'],
+  'Nissan': ['Versa', 'Sentra', 'Altima', 'March', 'Frontier', 'Kicks', 'X-Trail', 'Pathfinder', 'Tsuru', 'NP300', 'V-Drive'],
+  'Volkswagen': ['Jetta', 'Golf', 'Tiguan', 'Vento', 'Polo', 'Taos', 'Virtus', 'Taigun', 'Nivus', 'Beetle'],
+  'Toyota': ['Corolla', 'Camry', 'RAV4', 'Tacoma', 'Yaris', 'Prius', 'Hilux', 'Sienna', 'Land Cruiser', 'Corolla Cross', 'Highlander'],
+  'Honda': ['Civic', 'Accord', 'CR-V', 'Fit', 'HR-V', 'City', 'Pilot', 'Odyssey', 'BR-V'],
+  'Ford': ['Mustang', 'Lobo', 'Explorer', 'Ranger', 'Focus', 'Escape', 'Bronco', 'F-150', 'Edge', 'Territory', 'Maverick'],
+  'BMW': ['Serie 3', 'Serie 1', 'X3', 'X5', 'Serie 5', 'X1', 'X6', 'Serie 4', 'X2'],
+  'Mercedes-Benz': ['Clase C', 'Clase A', 'GLC', 'GLE', 'Clase E', 'GLA', 'CLA', 'GLB'],
+  'Audi': ['A3', 'A4', 'Q3', 'Q5', 'A1', 'A6', 'Q7', 'Q2'],
+  'Kia': ['Rio', 'Forte', 'Sportage', 'Seltos', 'Soul', 'Sorento', 'Picanto', 'K3'],
+  'Hyundai': ['Accent', 'Elantra', 'Tucson', 'Creta', 'Santa Fe', 'Grand i10', 'Venue', 'Kona'],
+  'Mazda': ['Mazda 3', 'Mazda 2', 'CX-30', 'CX-5', 'CX-3', 'Mazda 6', 'MX-5', 'CX-50'],
+  'Jeep': ['Grand Cherokee', 'Wrangler', 'Compass', 'Renegade', 'Cherokee', 'Gladiator'],
+  'Tesla': ['Model 3', 'Model Y', 'Model S', 'Model X'],
+  'MG': ['MG5', 'HS', 'ZS', 'RX5', 'GT', 'One'],
+  'BYD': ['Dolphin', 'Yuan Plus', 'Song Plus', 'Han', 'Tang', 'Seal'],
+  'SEAT': ['Ibiza', 'León', 'Ateca', 'Arona', 'Tarraco'],
+  'Renault': ['Kwid', 'Kangoo', 'Duster', 'Logan', 'Stepway', 'Oroch', 'Captur'],
+  'Peugeot': ['208', '2008', '3008', '308', 'Partner', '408'],
+  'Mitsubishi': ['L200', 'Outlander', 'ASX', 'Mirage', 'Eclipse Cross', 'Xpander'],
+  'Suzuki': ['Swift', 'Vitara', 'Ciaz', 'S-Cross', 'Jimny'],
+  'RAM': ['700', '1500', '2500', 'ProMaster'],
+  'Dodge': ['Attitude', 'Journey', 'Durango', 'Ram (versión anterior)'],
+  'Chirey': ['Tiggo 2', 'Tiggo 7', 'Tiggo 8', 'Arrizo 5'],
+  'Chrysler': ['300', 'Pacifica', 'Voyager'],
+  'GMC': ['Sierra', 'Terrain', 'Yukon', 'Acadia', 'Canyon'],
+  'Cadillac': ['Escalade', 'XT4', 'XT5', 'XT6', 'CT5'],
+  'Buick': ['Encore', 'Envision', 'Enclave'],
+  'Lincoln': ['Nautilus', 'Aviator', 'Corsair', 'Navigator'],
+  'Subaru': ['Forester', 'Outback', 'Impreza', 'XV', 'Crosstrek'],
+  'Lexus': ['NX', 'RX', 'ES', 'UX', 'GX'],
+  'Acura': ['ILX', 'RDX', 'MDX', 'TLX'],
+  'Infiniti': ['Q50', 'QX50', 'QX60'],
+  'Isuzu': ['D-Max', 'MU-X', 'NPR'],
+  'Genesis': ['G70', 'G80', 'GV70', 'GV80'],
+  'Porsche': ['911', 'Cayenne', 'Macan', 'Panamera', 'Taycan'],
+  'MINI': ['Cooper', 'Countryman', 'Clubman'],
+  'Smart': ['Fortwo', 'Forfour'],
+  'Citroën': ['C3', 'C4', 'Berlingo', 'C3 Aircross'],
+  'Fiat': ['500', 'Mobi', 'Argo', 'Pulse', 'Strada'],
+  'Alfa Romeo': ['Giulia', 'Stelvio', 'Tonale'],
+  'Volvo': ['XC40', 'XC60', 'XC90', 'S60'],
+  'Land Rover': ['Range Rover', 'Range Rover Sport', 'Discovery', 'Defender', 'Evoque'],
+  'Jaguar': ['F-Pace', 'XE', 'XF', 'E-Pace'],
+  'JAC': ['Sei4', 'JS4', 'S3'],
+  'GWM (Haval)': ['H6', 'Jolion', 'H9', 'Poer'],
+  'Changan': ['CS35 Plus', 'CS55', 'Alsvin'],
+  'Omoda/Jaecoo': ['Omoda 5', 'Jaecoo 5', 'Jaecoo 7'],
+  'DFSK': ['Glory 580', 'Glory 500', 'K01'],
+  'Foton': ['Toano', 'View', 'Tunland'],
+  'Scania': ['R-Series', 'P-Series', 'G-Series'],
+  'International': ['DuraStar', 'ProStar', 'IC Bus'],
+  'Freightliner': ['Cascadia', 'M2', 'Coronado'],
+  'MAN': ['TGX', 'TGS', 'Lion\'s Coach'],
+  'Iveco': ['Daily', 'Eurocargo', 'Stralis'],
+  'Dina': ['Linner', 'Avante', 'Ciela'],
+  'Hino': ['300', '500', '700'],
+};
 
 const electronicsBrands = [
   'Apple', 'Samsung', 'Xiaomi', 'Motorola', 'Huawei', 'Oppo', 'Google Pixel', 'Honor',

--- a/src/constants/locationsAndCategories.js
+++ b/src/constants/locationsAndCategories.js
@@ -34,7 +34,7 @@ export const mexicoLocations = {
 };
 
 export const subcategoriesMap = {
-  'motor': ['Compactos', 'SUV', 'Pickup', 'Sedán', 'Hatchback', 'Coupé', 'Deportivos', 'Clásicos', 'Eléctricos', 'Accesorios', 'Camiones', 'Motos', 'Scooters', 'Cuatrimotos', 'UTV', 'Motos de agua', 'Refacciones', 'Cascos', 'Equipamiento'],
+  'motor': ['Compactos', 'SUV', 'Pickup', 'Sedán', 'Hatchback', 'Coupé', 'Deportivos', 'Clásicos', 'Eléctricos', 'Accesorios', 'Camiones', 'Autobuses', 'Motos', 'Scooters', 'Cuatrimotos', 'UTV', 'Motos de agua', 'Refacciones', 'Cascos', 'Equipamiento'],
   'inmobiliaria': ['Casas en venta', 'Casas en renta', 'Departamentos', 'Terrenos', 'Locales comerciales', 'Oficinas', 'Bodegas', 'Renta vacacional'],
   'empleo': ['Ventas', 'Chofer', 'Construcción', 'Administración', 'Atención al cliente', 'Tecnología', 'Hotelería', 'Medio tiempo'],
   'servicios': ['Mudanzas', 'Limpieza', 'Plomería', 'Electricidad', 'Cerrajería', 'Clases', 'Diseño', 'Eventos'],

--- a/src/constants/subcategoryTranslations.js
+++ b/src/constants/subcategoryTranslations.js
@@ -2,7 +2,7 @@
 // Falls back to Spanish (the canonical taxonomy) for any language/category not listed here.
 export const subcategoriesByLang = {
   es: {
-    motor: ['Compactos', 'SUV', 'Pickup', 'Sedán', 'Hatchback', 'Coupé', 'Deportivos', 'Clásicos', 'Eléctricos', 'Accesorios', 'Camiones', 'Motos', 'Scooters', 'Cuatrimotos', 'UTV', 'Motos de agua', 'Refacciones', 'Cascos', 'Equipamiento'],
+    motor: ['Compactos', 'SUV', 'Pickup', 'Sedán', 'Hatchback', 'Coupé', 'Deportivos', 'Clásicos', 'Eléctricos', 'Accesorios', 'Camiones', 'Autobuses', 'Motos', 'Scooters', 'Cuatrimotos', 'UTV', 'Motos de agua', 'Refacciones', 'Cascos', 'Equipamiento'],
     inmobiliaria: ['Casas en venta', 'Casas en renta', 'Departamentos', 'Terrenos', 'Locales comerciales', 'Oficinas', 'Bodegas', 'Renta vacacional'],
     empleo: ['Ventas', 'Chofer', 'Construcción', 'Administración', 'Atención al cliente', 'Tecnología', 'Hotelería', 'Medio tiempo'],
     servicios: ['Mudanzas', 'Limpieza', 'Plomería', 'Electricidad', 'Cerrajería', 'Clases', 'Diseño', 'Eventos'],
@@ -35,7 +35,7 @@ export const subcategoriesByLang = {
     },
   },
   en: {
-    motor: ['Compact cars', 'SUVs', 'Pickup trucks', 'Sedans', 'Hatchbacks', 'Coupes', 'Sports cars', 'Classic cars', 'Electric cars', 'Accessories', 'Trucks', 'Motorcycles', 'Scooters', 'ATVs', 'UTVs', 'Jet skis', 'Parts', 'Helmets', 'Gear'],
+    motor: ['Compact cars', 'SUVs', 'Pickup trucks', 'Sedans', 'Hatchbacks', 'Coupes', 'Sports cars', 'Classic cars', 'Electric cars', 'Accessories', 'Trucks', 'Buses', 'Motorcycles', 'Scooters', 'ATVs', 'UTVs', 'Jet skis', 'Parts', 'Helmets', 'Gear'],
     inmobiliaria: ['Houses for sale', 'Houses for rent', 'Apartments', 'Land', 'Commercial spaces', 'Offices', 'Warehouses', 'Vacation rentals'],
     empleo: ['Sales', 'Driver', 'Construction', 'Administration', 'Customer service', 'Technology', 'Hospitality', 'Part-time'],
     servicios: ['Moving', 'Cleaning', 'Plumbing', 'Electrical', 'Locksmith', 'Classes', 'Design', 'Events'],
@@ -68,7 +68,7 @@ export const subcategoriesByLang = {
     },
   },
   fr: {
-    motor: ['Citadines', 'SUV', 'Pick-up', 'Berlines', 'Compactes à hayon', 'Coupés', 'Voitures de sport', 'Voitures classiques', 'Voitures électriques', 'Accessoires', 'Camions', 'Motos', 'Scooters', 'Quads', 'UTV', 'Motomarines', 'Pièces détachées', 'Casques', 'Équipement'],
+    motor: ['Citadines', 'SUV', 'Pick-up', 'Berlines', 'Compactes à hayon', 'Coupés', 'Voitures de sport', 'Voitures classiques', 'Voitures électriques', 'Accessoires', 'Camions', 'Autobus', 'Motos', 'Scooters', 'Quads', 'UTV', 'Motomarines', 'Pièces détachées', 'Casques', 'Équipement'],
     inmobiliaria: ['Maisons à vendre', 'Maisons à louer', 'Appartements', 'Terrains', 'Locaux commerciaux', 'Bureaux', 'Entrepôts', 'Locations de vacances'],
     empleo: ['Ventes', 'Chauffeur', 'Construction', 'Administration', 'Service client', 'Technologie', 'Hôtellerie', 'Temps partiel'],
     servicios: ['Déménagement', 'Nettoyage', 'Plomberie', 'Électricité', 'Serrurerie', 'Cours', 'Design', 'Événements'],
@@ -101,7 +101,7 @@ export const subcategoriesByLang = {
     },
   },
   de: {
-    motor: ['Kompaktwagen', 'SUV', 'Pickup', 'Limousinen', 'Kompaktklasse', 'Coupés', 'Sportwagen', 'Oldtimer', 'Elektroautos', 'Zubehör', 'Lastwagen', 'Motorräder', 'Roller', 'Quads', 'UTV', 'Jetskis', 'Ersatzteile', 'Helme', 'Ausrüstung'],
+    motor: ['Kompaktwagen', 'SUV', 'Pickup', 'Limousinen', 'Kompaktklasse', 'Coupés', 'Sportwagen', 'Oldtimer', 'Elektroautos', 'Zubehör', 'Lastwagen', 'Busse', 'Motorräder', 'Roller', 'Quads', 'UTV', 'Jetskis', 'Ersatzteile', 'Helme', 'Ausrüstung'],
     inmobiliaria: ['Häuser zu verkaufen', 'Häuser zu vermieten', 'Wohnungen', 'Grundstücke', 'Gewerbeflächen', 'Büros', 'Lagerhallen', 'Ferienvermietung'],
     empleo: ['Verkauf', 'Fahrer', 'Bau', 'Verwaltung', 'Kundenservice', 'Technologie', 'Gastgewerbe', 'Teilzeit'],
     servicios: ['Umzüge', 'Reinigung', 'Klempnerei', 'Elektrik', 'Schlüsseldienst', 'Kurse', 'Design', 'Veranstaltungen'],
@@ -134,7 +134,7 @@ export const subcategoriesByLang = {
     },
   },
   it: {
-    motor: ['Compatte', 'SUV', 'Pickup', 'Berline', 'Utilitarie', 'Coupé', 'Auto sportive', "Auto d'epoca", 'Auto elettriche', 'Accessori', 'Camion', 'Moto', 'Scooter', 'Quad', 'UTV', "Moto d'acqua", 'Ricambi', 'Caschi', 'Equipaggiamento'],
+    motor: ['Compatte', 'SUV', 'Pickup', 'Berline', 'Utilitarie', 'Coupé', 'Auto sportive', "Auto d'epoca", 'Auto elettriche', 'Accessori', 'Camion', 'Autobus', 'Moto', 'Scooter', 'Quad', 'UTV', "Moto d'acqua", 'Ricambi', 'Caschi', 'Equipaggiamento'],
     inmobiliaria: ['Case in vendita', 'Case in affitto', 'Appartamenti', 'Terreni', 'Locali commerciali', 'Uffici', 'Magazzini', 'Affitti vacanze'],
     empleo: ['Vendite', 'Autista', 'Edilizia', 'Amministrazione', 'Servizio clienti', 'Tecnologia', 'Ospitalità', 'Part-time'],
     servicios: ['Traslochi', 'Pulizie', 'Idraulica', 'Elettricità', 'Fabbro', 'Corsi', 'Design', 'Eventi'],
@@ -167,7 +167,7 @@ export const subcategoriesByLang = {
     },
   },
   pt: {
-    motor: ['Compactos', 'SUV', 'Picapes', 'Sedãs', 'Hatchbacks', 'Cupês', 'Esportivos', 'Clássicos', 'Elétricos', 'Acessórios', 'Caminhões', 'Motos', 'Scooters', 'Quadriciclos', 'UTV', 'Jet skis', 'Peças', 'Capacetes', 'Equipamentos'],
+    motor: ['Compactos', 'SUV', 'Picapes', 'Sedãs', 'Hatchbacks', 'Cupês', 'Esportivos', 'Clássicos', 'Elétricos', 'Acessórios', 'Caminhões', 'Ônibus', 'Motos', 'Scooters', 'Quadriciclos', 'UTV', 'Jet skis', 'Peças', 'Capacetes', 'Equipamentos'],
     inmobiliaria: ['Casas à venda', 'Casas para alugar', 'Apartamentos', 'Terrenos', 'Pontos comerciais', 'Escritórios', 'Galpões', 'Aluguel de temporada'],
     empleo: ['Vendas', 'Motorista', 'Construção', 'Administração', 'Atendimento ao cliente', 'Tecnologia', 'Hotelaria', 'Meio período'],
     servicios: ['Mudanças', 'Limpeza', 'Encanamento', 'Elétrica', 'Chaveiro', 'Aulas', 'Design', 'Eventos'],
@@ -200,7 +200,7 @@ export const subcategoriesByLang = {
     },
   },
   ru: {
-    motor: ['Компактные', 'Внедорожники', 'Пикапы', 'Седаны', 'Хэтчбеки', 'Купе', 'Спортивные', 'Классические', 'Электромобили', 'Аксессуары', 'Грузовики', 'Мотоциклы', 'Скутеры', 'Квадроциклы', 'Багги (UTV)', 'Гидроциклы', 'Запчасти', 'Шлемы', 'Экипировка'],
+    motor: ['Компактные', 'Внедорожники', 'Пикапы', 'Седаны', 'Хэтчбеки', 'Купе', 'Спортивные', 'Классические', 'Электромобили', 'Аксессуары', 'Грузовики', 'Автобусы', 'Мотоциклы', 'Скутеры', 'Квадроциклы', 'Багги (UTV)', 'Гидроциклы', 'Запчасти', 'Шлемы', 'Экипировка'],
     inmobiliaria: ['Дома продажа', 'Дома аренда', 'Квартиры', 'Земельные участки', 'Коммерческие помещения', 'Офисы', 'Склады', 'Аренда для отдыха'],
     empleo: ['Продажи', 'Водитель', 'Строительство', 'Администрирование', 'Работа с клиентами', 'Технологии', 'Гостиничное дело', 'Подработка'],
     servicios: ['Переезды', 'Уборка', 'Сантехника', 'Электрика', 'Услуги слесаря', 'Курсы', 'Дизайн', 'Мероприятия'],
@@ -233,7 +233,7 @@ export const subcategoriesByLang = {
     },
   },
   zh: {
-    motor: ['紧凑型车', 'SUV', '皮卡', '轿车', '掀背车', '双门轿跑车', '跑车', '经典车', '电动车', '配件', '卡车', '摩托车', '踏板车', '沙滩车', '全地形车', '水上摩托', '配件', '头盔', '装备'],
+    motor: ['紧凑型车', 'SUV', '皮卡', '轿车', '掀背车', '双门轿跑车', '跑车', '经典车', '电动车', '配件', '卡车', '巴士', '摩托车', '踏板车', '沙滩车', '全地形车', '水上摩托', '配件', '头盔', '装备'],
     inmobiliaria: ['出售房屋', '出租房屋', '公寓', '土地', '商铺', '办公室', '仓库', '度假租赁'],
     empleo: ['销售', '司机', '建筑', '行政', '客户服务', '技术', '酒店业', '兼职'],
     servicios: ['搬家', '清洁', '水管工', '电工', '开锁服务', '课程', '设计', '活动'],
@@ -266,7 +266,7 @@ export const subcategoriesByLang = {
     },
   },
   ja: {
-    motor: ['コンパクトカー', 'SUV', 'ピックアップトラック', 'セダン', 'ハッチバック', 'クーペ', 'スポーツカー', 'クラシックカー', '電気自動車', 'アクセサリー', 'トラック', 'バイク', 'スクーター', 'ATV', 'UTV', '水上バイク', 'パーツ', 'ヘルメット', '装備'],
+    motor: ['コンパクトカー', 'SUV', 'ピックアップトラック', 'セダン', 'ハッチバック', 'クーペ', 'スポーツカー', 'クラシックカー', '電気自動車', 'アクセサリー', 'トラック', 'バス', 'バイク', 'スクーター', 'ATV', 'UTV', '水上バイク', 'パーツ', 'ヘルメット', '装備'],
     inmobiliaria: ['販売住宅', '賃貸住宅', 'アパート', '土地', '商業スペース', 'オフィス', '倉庫', 'バケーションレンタル'],
     empleo: ['営業', 'ドライバー', '建設', '事務', 'カスタマーサービス', 'テクノロジー', 'ホスピタリティ', 'パートタイム'],
     servicios: ['引っ越し', '清掃', '配管工事', '電気工事', '鍵屋', '講座', 'デザイン', 'イベント'],
@@ -299,7 +299,7 @@ export const subcategoriesByLang = {
     },
   },
   ko: {
-    motor: ['소형차', 'SUV', '픽업트럭', '세단', '해치백', '쿠페', '스포츠카', '클래식카', '전기차', '액세서리', '트럭', '오토바이', '스쿠터', 'ATV', 'UTV', '수상 오토바이', '부품', '헬멧', '장비'],
+    motor: ['소형차', 'SUV', '픽업트럭', '세단', '해치백', '쿠페', '스포츠카', '클래식카', '전기차', '액세서리', '트럭', '버스', '오토바이', '스쿠터', 'ATV', 'UTV', '수상 오토바이', '부품', '헬멧', '장비'],
     inmobiliaria: ['주택 매매', '주택 임대', '아파트', '토지', '상업 공간', '사무실', '창고', '휴가용 임대'],
     empleo: ['영업', '운전기사', '건설', '행정', '고객 서비스', '기술', '호텔업', '파트타임'],
     servicios: ['이사', '청소', '배관', '전기', '열쇠공', '강좌', '디자인', '이벤트'],
@@ -332,7 +332,7 @@ export const subcategoriesByLang = {
     },
   },
   ar: {
-    motor: ['سيارات مدمجة', 'دفع رباعي', 'بيك أب', 'سيدان', 'هاتشباك', 'كوبيه', 'سيارات رياضية', 'سيارات كلاسيكية', 'سيارات كهربائية', 'إكسسوارات', 'شاحنات', 'دراجات نارية', 'سكوتر', 'دراجات رباعية', 'مركبات UTV', 'دراجات مائية', 'قطع غيار', 'خوذات', 'معدات'],
+    motor: ['سيارات مدمجة', 'دفع رباعي', 'بيك أب', 'سيدان', 'هاتشباك', 'كوبيه', 'سيارات رياضية', 'سيارات كلاسيكية', 'سيارات كهربائية', 'إكسسوارات', 'شاحنات', 'حافلات', 'دراجات نارية', 'سكوتر', 'دراجات رباعية', 'مركبات UTV', 'دراجات مائية', 'قطع غيار', 'خوذات', 'معدات'],
     inmobiliaria: ['منازل للبيع', 'منازل للإيجار', 'شقق', 'أراضٍ', 'محلات تجارية', 'مكاتب', 'مستودعات', 'إيجار عطلات'],
     empleo: ['مبيعات', 'سائق', 'بناء', 'إدارة', 'خدمة العملاء', 'تقنية', 'ضيافة', 'دوام جزئي'],
     servicios: ['نقل عفش', 'تنظيف', 'سباكة', 'كهرباء', 'أعمال أقفال', 'دورات', 'تصميم', 'فعاليات'],
@@ -365,7 +365,7 @@ export const subcategoriesByLang = {
     },
   },
   he: {
-    motor: ['רכבים קומפקטיים', 'רכבי שטח', 'טנדרים', 'סדאן', "האצ'בק", 'קופה', 'מכוניות ספורט', 'מכוניות קלאסיות', 'רכבים חשמליים', 'אביזרים', 'משאיות', 'אופנועים', 'קטנועים', 'טרקטורונים', 'רכבי UTV', 'אופנועי ים', 'חלקי חילוף', 'קסדות', 'ציוד'],
+    motor: ['רכבים קומפקטיים', 'רכבי שטח', 'טנדרים', 'סדאן', "האצ'בק", 'קופה', 'מכוניות ספורט', 'מכוניות קלאסיות', 'רכבים חשמליים', 'אביזרים', 'משאיות', 'אוטובוסים', 'אופנועים', 'קטנועים', 'טרקטורונים', 'רכבי UTV', 'אופנועי ים', 'חלקי חילוף', 'קסדות', 'ציוד'],
     inmobiliaria: ['בתים למכירה', 'בתים להשכרה', 'דירות', 'קרקעות', 'שטחים מסחריים', 'משרדים', 'מחסנים', 'השכרות נופש'],
     empleo: ['מכירות', 'נהג', 'בנייה', 'מנהלה', 'שירות לקוחות', 'טכנולוגיה', 'אירוח', 'משרה חלקית'],
     servicios: ['הובלות', 'ניקיון', 'אינסטלציה', 'חשמל', 'מנעולנות', 'קורסים', 'עיצוב', 'אירועים'],
@@ -398,7 +398,7 @@ export const subcategoriesByLang = {
     },
   },
   yi: {
-    motor: ['קאמפאקטע אויטאס', 'SUV', 'פיקאפ', 'סעדאן', "האטשבעק", 'קופע', 'ספארט אויטאס', 'קלאסישע אויטאס', 'עלעקטרישע אויטאס', 'אקסעסאריז', 'לאָריס', 'מאטאציקלען', 'סקוטערס', 'קוואדראציקלען', 'UTV', 'וואסער-מאטאציקלען', 'טיילן', 'העלמען', 'געציג'],
+    motor: ['קאמפאקטע אויטאס', 'SUV', 'פיקאפ', 'סעדאן', "האטשבעק", 'קופע', 'ספארט אויטאס', 'קלאסישע אויטאס', 'עלעקטרישע אויטאס', 'אקסעסאריז', 'לאָריס', 'אויטאבוסן', 'מאטאציקלען', 'סקוטערס', 'קוואדראציקלען', 'UTV', 'וואסער-מאטאציקלען', 'טיילן', 'העלמען', 'געציג'],
     inmobiliaria: ['הייזער צום פארקויפן', 'הייזער צום דינגען', 'דירות', 'ערד', 'געשעפט פלעצער', 'אפיסעס', 'לאגער הייזער', 'וואקאציע דינגען'],
     empleo: ['פארקויף', 'שאפער', 'בוי', 'אדמיניסטראציע', 'קונים סערוויס', 'טעכנאלאגיע', 'האטעלערייע', 'טייל-צייט'],
     servicios: ['איבערפירן', 'ריינקייט', 'רערן ארבעט', 'עלעקטריק', 'שלעסער', 'קלאסן', 'דיזיין', 'געשעענישן'],


### PR DESCRIPTION
…subcategory

Expanded the "Motor" category's brand coverage far beyond the original 7-brand list, to match what's actually sold/imported in Mexico:

- North America: Chevrolet, Ford, RAM, Dodge, Jeep, Chrysler, GMC, Cadillac, Buick, Lincoln, Tesla
- Japan/Korea: Toyota, Honda, Nissan, Mazda, Mitsubishi, Suzuki, Subaru, Lexus, Acura, Infiniti, Isuzu, Kia, Hyundai, Genesis
- Germany: Volkswagen, BMW, Mercedes-Benz, Audi, Porsche, MINI, Smart
- Europe (other): SEAT, Renault, Peugeot, Citroën, Fiat, Alfa Romeo, Volvo, Land Rover, Jaguar
- China: BYD, MG, Chirey, JAC, GWM (Haval), Changan, Omoda/Jaecoo, DFSK, Foton
- Commercial trucks/buses: Scania, International, Freightliner, MAN, Iveco, Dina, Hino

Added a real model list per brand (autoModelsByBrand in filterConfig.js) and wired a dependent Marca -> Modelo select into PostScreen's dynamic attribute renderer — picking a brand now shows its actual current models instead of a free-text field; "Otro" still falls back to text for anything not listed, so nobody is blocked.

Also added "Autobuses"/buses as its own Motor subcategory (13 languages) — was missing even after the earlier trucks fix.

The brand *options* users see when posting are ultimately served by the backend category_attributes table (fetched live), not just the frontend fallback, so this includes a migration
(2026_07_04_000002_expand_motor_marca_options) updating the existing 'motor'/'marca' row to the same expanded list, plus the equivalent update in CategoryAttributeSeeder.php for fresh installs.

Scope note: this covers current/recent models per brand, not an exhaustive historical/retro catalog — deliberately avoided inventing older generations or trims I'm not certain existed, since a wrong "real-looking" option is worse than a working free-text fallback. Motorcycles, boats, jet skis, and bicycles are unchanged in this pass.

## Summary

-

## Agent owner

-

## Risk level

- [ ] Low: docs/copy/non-runtime
- [ ] Medium: UI/backend behavior but no sensitive areas
- [ ] High: auth/payments/uploads/database/infra/security
- [ ] Critical: production/secrets/destructive operations

## Two-step critique

### Critique 1: risk and correctness

-

### Critique 2: alternatives and quality

-

## Changed areas

- [ ] Frontend
- [ ] Backend/API
- [ ] Database
- [ ] Docker/infra
- [ ] Security/auth
- [ ] Payments/Clip
- [ ] AI/ML
- [ ] SEO/content
- [ ] Documentation only

## Smoke tests

-

## Rollback plan

-

## Human approval needed?

- [ ] No
- [ ] Yes — auth, payments, secrets, database destructive changes, Docker networking, DNS, production deploy, or legal/policy changes

## Screenshots / evidence

-
