### PR TITLE
feat: finish and ship the in-app buyer-seller chat

### DIFF
--- a/backend/app/Http/Controllers/Api/ChatController.php
+++ b/backend/app/Http/Controllers/Api/ChatController.php
@@ -18,7 +18,9 @@ class ChatController extends Controller {
                     'ad:id,title,price,image_url',
                     'buyer:id,name,avatar_url',
                     'seller:id,name,avatar_url',
-                    'latestMessage:id,conversation_id,sender_id,body,read_at,created_at',
+                    // Column-restricted eager load collides with latestOfMany()'s own subquery
+                    // column (ambiguous "conversation_id" on some drivers) — load unrestricted.
+                    'latestMessage',
                 ])
                 ->where('buyer_id', $userId)
                 ->orWhere('seller_id', $userId)
@@ -99,24 +101,37 @@ class ChatController extends Controller {
             $adId = $request->filled('ad_id') ? (int) $request->ad_id : null;
             $ad = $adId ? Ad::select('id', 'user_id', 'title')->find($adId) : null;
 
-            $sellerId = $ad?->user_id ?: $receiverId;
-            $buyerId = $userId === $sellerId ? $receiverId : $userId;
+            // Reuse whichever conversation already exists between these two users for this ad
+            // (in either buyer/seller role) instead of re-deriving buyer/seller from who's
+            // sending vs receiving — that flips per message direction and split every reply
+            // into a brand new duplicate conversation.
+            $conversation = Conversation::where('ad_id', $adId)
+                ->where(function ($query) use ($userId, $receiverId) {
+                    $query->where(['buyer_id' => $userId, 'seller_id' => $receiverId])
+                        ->orWhere(['buyer_id' => $receiverId, 'seller_id' => $userId]);
+                })
+                ->first();
 
-            $conversation = Conversation::firstOrCreate(
-                [
+            if (! $conversation) {
+                $sellerId = $ad?->user_id ?: $receiverId;
+                $buyerId = $userId === $sellerId ? $receiverId : $userId;
+                $conversation = Conversation::create([
                     'buyer_id' => $buyerId,
                     'seller_id' => $sellerId,
                     'ad_id' => $adId,
-                ],
-                [
                     'status' => 'active',
                     'last_message_at' => now(),
-                ]
-            );
+                ]);
+            }
 
             $message = Message::create([
                 'conversation_id' => $conversation->id,
                 'sender_id' => $userId,
+                // receiver_id/content predate the conversations schema and are still NOT NULL;
+                // kept in sync with buyer/seller + body rather than a migration (no doctrine/dbal
+                // installed, so Blueprint::change() isn't available to make them nullable).
+                'receiver_id' => $receiverId,
+                'content' => $request->content,
                 'body' => $request->content,
                 'type' => 'text',
             ]);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\Api\SearchAlertController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\ContactController;
+use App\Http\Controllers\Api\ChatController;
 use App\Http\Controllers\Api\MetaEventController;
 
 // Public routes
@@ -304,6 +305,11 @@ Route::middleware('auth:sanctum')->group(function () {
     // Meta CAPI events (Authenticated)
     Route::post('/meta/events/post-ad', [MetaEventController::class, 'postAd']);
     Route::post('/meta/events/wishlist', [MetaEventController::class, 'addToWishlist']);
+
+    // Chat interno comprador-vendedor (real-time vía Reverb, ver routes/channels.php)
+    Route::get('/conversations', [ChatController::class, 'getConversations']);
+    Route::get('/conversations/{otherUserId}/messages', [ChatController::class, 'getMessages'])->whereNumber('otherUserId');
+    Route::middleware('throttle:30,1')->post('/messages', [ChatController::class, 'sendMessage']); // 30 mensajes/minuto por usuario
 });
 
 // Meta CAPI events (Public)

--- a/backend/routes/channels.php
+++ b/backend/routes/channels.php
@@ -1,3 +1,5 @@
 <?php
 use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) { return (int) $user->id === (int) $id; });
+// Chat interno: MessageSent transmite a chat.{receiverId} (App/Events/MessageSent.php)
+Broadcast::channel('chat.{id}', function ($user, $id) { return (int) $user->id === (int) $id; });

--- a/backend/tests/Feature/ChatControllerTest.php
+++ b/backend/tests/Feature/ChatControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Ad;
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChatControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sending_a_message_creates_a_conversation_and_delivers_it()
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+
+        $response = $this->actingAs($buyer, 'sanctum')->postJson('/api/messages', [
+            'receiver_id' => $seller->id,
+            'content' => 'Hola, sigue disponible?',
+        ]);
+
+        $response->assertStatus(200)->assertJsonFragment(['content' => 'Hola, sigue disponible?']);
+
+        $inbox = $this->actingAs($seller, 'sanctum')->getJson('/api/conversations');
+        $inbox->assertStatus(200)->assertJsonFragment(['name' => $buyer->name, 'unread_count' => 1]);
+    }
+
+    /**
+     * Regression test: sendMessage() used to derive buyer/seller roles from who was
+     * sending vs. receiving on each call (instead of from a stable identity for the
+     * pair), so every reply without an ad_id created a brand new Conversation row
+     * instead of continuing the existing thread.
+     */
+    public function test_replies_without_an_ad_id_reuse_the_same_conversation()
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $this->actingAs($userA, 'sanctum')->postJson('/api/messages', [
+            'receiver_id' => $userB->id,
+            'content' => 'Mensaje 1',
+        ])->assertStatus(200);
+
+        $this->actingAs($userB, 'sanctum')->postJson('/api/messages', [
+            'receiver_id' => $userA->id,
+            'content' => 'Mensaje 2',
+        ])->assertStatus(200);
+
+        $this->actingAs($userA, 'sanctum')->postJson('/api/messages', [
+            'receiver_id' => $userB->id,
+            'content' => 'Mensaje 3',
+        ])->assertStatus(200);
+
+        $this->assertEquals(1, \App\Models\Conversation::count());
+
+        $inboxA = $this->actingAs($userA, 'sanctum')->getJson('/api/conversations');
+        $inboxA->assertStatus(200)->assertJsonCount(1);
+    }
+
+    public function test_conversation_can_be_scoped_to_an_ad()
+    {
+        Category::create(['slug' => 'electronica', 'name' => ['es' => 'Electrónica', 'en' => 'Electronics'], 'icon' => 'Monitor']);
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $ad = Ad::create([
+            'user_id' => $seller->id,
+            'title' => 'iPhone 14',
+            'price' => 12000,
+            'description' => 'Como nuevo',
+            'category' => 'electronica',
+            'condition' => 'usado',
+            'status' => 'active',
+            'location' => 'CDMX',
+        ]);
+
+        $response = $this->actingAs($buyer, 'sanctum')->postJson('/api/messages', [
+            'receiver_id' => $seller->id,
+            'content' => 'Me interesa tu iPhone',
+            'ad_id' => $ad->id,
+        ]);
+
+        $response->assertStatus(200)->assertJsonFragment(['ad_id' => $ad->id]);
+    }
+
+    public function test_a_user_cannot_read_a_conversation_they_are_not_part_of()
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $outsider = User::factory()->create();
+
+        $this->actingAs($buyer, 'sanctum')->postJson('/api/messages', [
+            'receiver_id' => $seller->id,
+            'content' => 'Hola',
+        ])->assertStatus(200);
+
+        $response = $this->actingAs($outsider, 'sanctum')->getJson("/api/conversations/{$buyer->id}/messages");
+        $response->assertStatus(200)->assertJsonCount(0);
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -395,6 +395,7 @@ const VerificarEmailScreen = React.lazy(() => import('./components/screens/Verif
 const AcercaDeScreen = React.lazy(() => import('./components/screens/AcercaDeScreen').catch(() => ({ default: () => <div className="flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500">No pudimos cargar esta página.</div> })));
 const StoresScreen = React.lazy(() => import('./components/screens/StoresScreen').catch(() => ({ default: () => <div className="flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500">No pudimos cargar el directorio de tiendas.</div> })));
 const NotificationsScreen = React.lazy(() => import('./components/screens/NotificationsScreen').catch(() => ({ default: () => <div className="flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500">No pudimos cargar las notificaciones.</div> })));
+const MessagesScreen = React.lazy(() => import('./components/screens/MessagesScreen').catch(() => ({ default: () => <div className="flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500">No pudimos cargar los mensajes.</div> })));
 const ContactoScreen  = React.lazy(() => import('./components/screens/ContactoScreen').catch(() => ({ default: () => <div className="flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500">No pudimos cargar esta página.</div> })));
 const AyudaScreen     = React.lazy(() => import('./components/screens/AyudaScreen').catch(() => ({ default: () => <div className="flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500">No pudimos cargar esta página.</div> })));
 const ReferralScreen = React.lazy(() => import('./components/screens/ReferralScreen').catch(() => ({ default: () => <div className='flex h-screen items-center justify-center p-10 text-center mt-20 text-slate-500'>No pudimos cargar esta página.</div> })));
@@ -637,6 +638,7 @@ function App() {
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   const [showTabBarMenu, setShowTabBarMenu] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
+  const [unreadMessagesCount, setUnreadMessagesCount] = useState(0);
   const [sliderAutoplay, setSliderAutoplay] = useState(() => localStorage.getItem('sliderAutoplay') !== 'false');
   const [notificationsForm, setNotificationsForm] = useState({ email_alerts: true, push_notifications: true, marketing: false });
   const [notificationsLoading, setNotificationsLoading] = useState(false);
@@ -1453,6 +1455,7 @@ function App() {
     if (!user?.id) return;
     let cancelled = false;
     let channel = null;
+    let chatChannel = null;
     // Lazy-load Echo + Pusher only for authenticated users — keeps 73 KB off the critical path
     getEcho().then((echo) => {
       if (cancelled || !echo) return;
@@ -1465,15 +1468,24 @@ function App() {
           // The actual notification data is inside e.notification
           setNotifications(prev => [e.notification, ...prev]);
       });
+      // Mensajes internos entrantes (MessagesScreen escucha el mismo canal para el hilo abierto)
+      chatChannel = echo.private(`chat.${user.id}`);
+      chatChannel.listen('.message.sent', () => {
+          setUnreadMessagesCount(prev => prev + 1);
+      });
     });
     return () => {
       cancelled = true;
       if (channel) {
         channel.stopListening('.NewNotification');
       }
-      // leave the private channel; echo may not be resolved yet — safe to ignore
+      if (chatChannel) {
+        chatChannel.stopListening('.message.sent');
+      }
+      // leave the private channels; echo may not be resolved yet — safe to ignore
       if (_echoInstance) {
         _echoInstance.leave(`private-App.Models.User.${user.id}`);
+        _echoInstance.leave(`private-chat.${user.id}`);
       }
     };
 // Защита от DDoS WebSockets (Connection Thrashing): привязываем зависимость ТОЛЬКО к ID,
@@ -1607,6 +1619,32 @@ function App() {
 
     fetchUnreadCount();
     const interval = setInterval(fetchUnreadCount, 60000);
+
+    return () => { clearInterval(interval); };
+  }, [user]);
+
+  // No hay endpoint dedicado de conteo — /conversations ya trae unread_count por hilo, se suma aquí.
+  useEffect(() => {
+    if (!user) {
+      setUnreadMessagesCount(0);
+      return undefined;
+    }
+
+    const fetchUnreadMessages = () => {
+      const token = localStorage.getItem('auth_token');
+      if (!token) return;
+      fetch(`${API_URL}/conversations`, { headers: { 'Authorization': `Bearer ${token}` } })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          if (Array.isArray(data)) {
+            setUnreadMessagesCount(data.reduce((sum, c) => sum + (c.unread_count || 0), 0));
+          }
+        })
+        .catch(() => {});
+    };
+
+    fetchUnreadMessages();
+    const interval = setInterval(fetchUnreadMessages, 60000);
 
     return () => { clearInterval(interval); };
   }, [user]);
@@ -3678,6 +3716,14 @@ function App() {
           <div className="space-y-1.5">
             {user && (
               <>
+                <button onClick={() => { navigate('/mensajes'); setShowTabBarMenu(false); }} className="profile-menu-item relative flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-900">
+                  <MessageCircle size={16} className="text-[#84CC16]" /> Mensajes
+                  {unreadMessagesCount > 0 && (
+                    <span className="ml-auto min-w-[18px] h-[18px] px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none">
+                      {unreadMessagesCount > 9 ? '9+' : unreadMessagesCount}
+                    </span>
+                  )}
+                </button>
                 <button onClick={() => { setCurrentTab('profile'); setDashboardTab('my_ads'); setShowTabBarMenu(false); }} className="profile-menu-item flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-900">
                   <User size={16} className="text-[#84CC16]" /> Mi cuenta
                 </button>
@@ -3934,6 +3980,14 @@ function App() {
                   </div>
                 )}
               </div>
+            <button type="button" onClick={() => { user ? navigate('/mensajes') : (setAuthMode('login'), setShowAuthModal(true)); }} className="header-icon-button relative p-2.5 rounded-xl hidden sm:block" aria-label="Mensajes" title="Mensajes">
+                <MessageCircle className="w-[22px] h-[22px]" />
+                {unreadMessagesCount > 0 && (
+                  <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center border-2 border-white leading-none">
+                    {unreadMessagesCount > 9 ? '9+' : unreadMessagesCount}
+                  </span>
+                )}
+              </button>
             <button onClick={() => { navigate('/tiendas'); setViewedAd(null); setViewedCompany(null); }} className="header-icon-button p-2.5 rounded-xl hidden sm:flex items-center gap-1.5 text-slate-600 dark:text-slate-300 hover:text-[#84CC16] transition-colors" title="Directorio de Tiendas">
                 <Store className="w-[22px] h-[22px]" />
                 <span className="text-[13px] font-bold hidden md:block">{navLabels[5]}</span>
@@ -4058,6 +4112,8 @@ function App() {
               <Route path="/publicar-gratis" element={<Navigate to="/vendedores" replace />} />
               <Route path="/post" element={<RequireAuth user={user} authReady={authReady} setAuthMode={setAuthMode} setShowAuthModal={setShowAuthModal}>{renderPostScreen()}</RequireAuth>} />
               <Route path="/notificaciones" element={<RequireAuth user={user} authReady={authReady} setAuthMode={setAuthMode} setShowAuthModal={setShowAuthModal}><React.Suspense fallback={<div className="flex h-screen items-center justify-center"><div className="w-8 h-8 rounded-full border-4 border-lime-500 border-t-transparent animate-spin"/></div>}><NotificationsScreen user={user} /></React.Suspense></RequireAuth>} />
+              <Route path="/mensajes" element={<RequireAuth user={user} authReady={authReady} setAuthMode={setAuthMode} setShowAuthModal={setShowAuthModal}><React.Suspense fallback={<div className="flex h-screen items-center justify-center"><div className="w-8 h-8 rounded-full border-4 border-lime-500 border-t-transparent animate-spin"/></div>}><MessagesScreen user={user} /></React.Suspense></RequireAuth>} />
+              <Route path="/mensajes/:userId" element={<RequireAuth user={user} authReady={authReady} setAuthMode={setAuthMode} setShowAuthModal={setShowAuthModal}><React.Suspense fallback={<div className="flex h-screen items-center justify-center"><div className="w-8 h-8 rounded-full border-4 border-lime-500 border-t-transparent animate-spin"/></div>}><MessagesScreen user={user} /></React.Suspense></RequireAuth>} />
               <Route path="/profile" element={<RequireAuth user={user} authReady={authReady} setAuthMode={setAuthMode} setShowAuthModal={setShowAuthModal}>{renderUserDashboard()}</RequireAuth>} />
               <Route path="/admin" element={<RequireAuth user={user} authReady={authReady} setAuthMode={setAuthMode} setShowAuthModal={setShowAuthModal} admin>{renderAdminScreen()}</RequireAuth>} />
               <Route path="/terms" element={<StaticPages currentTab="terms" />} />

--- a/src/components/common/ContactButton.jsx
+++ b/src/components/common/ContactButton.jsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { X, MessageCircle, Mail, Phone, Shield, AlertTriangle, Copy, Check } from 'lucide-react';
 
 const API_URL = import.meta.env.VITE_API_BASE_URL || 'https://mercasto.com/api';
 
 export default function ContactButton({ ad, user, className = '' }) {
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [sending, setSending] = useState(false);
@@ -51,6 +53,8 @@ export default function ContactButton({ ad, user, className = '' }) {
   const whatsappUrl = whatsappNumber ? `https://wa.me/${whatsappNumber}?text=${whatsappMessage}` : null;
   const telegramUrl = telegramUsername ? `https://t.me/${telegramUsername}` : null;
   const phoneUrl = phone ? `tel:+${phone}` : null;
+  const sellerId = ad?.user_id || ad?.user?.id || null;
+  const isOwnAd = user?.id && sellerId && user.id === sellerId;
 
   // Email-канал siempre disponible vía backend relay
   const hasContacts = true;
@@ -110,6 +114,12 @@ export default function ContactButton({ ad, user, className = '' }) {
   const handlePhoneClick = () => {
     logContact('phone');
     window.location.href = phoneUrl;
+  };
+
+  const handleInternalMessageClick = () => {
+    logContact('internal_message');
+    setIsOpen(false);
+    navigate(`/mensajes/${sellerId}${ad?.id ? `?ad_id=${ad.id}` : ''}`);
   };
 
   const handleCopyPhone = () => {
@@ -232,6 +242,24 @@ export default function ContactButton({ ad, user, className = '' }) {
                 </div>
               ) : (
                 <div className="space-y-3">
+                  {sellerId && !isOwnAd && (
+                    <button
+                      onClick={handleInternalMessageClick}
+                      className="w-full flex items-center gap-4 p-4 bg-lime-50 dark:bg-lime-500/10 hover:bg-lime-100 dark:hover:bg-lime-500/20 border border-lime-200 dark:border-lime-500/30 rounded-xl transition-all group"
+                    >
+                      <div className="w-12 h-12 rounded-full bg-[#84CC16] flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                        <MessageCircle className="w-6 h-6 text-slate-950" />
+                      </div>
+                      <div className="flex-1 text-left">
+                        <div className="font-semibold text-gray-900 dark:text-white">Mensaje por Mercasto</div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">Chatea sin salir del sitio</div>
+                      </div>
+                      <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                  )}
+
                   {whatsappUrl && (
                 <button
                   onClick={handleWhatsAppClick}

--- a/src/components/screens/MessagesScreen.jsx
+++ b/src/components/screens/MessagesScreen.jsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { ArrowLeft, Send, MessageCircle } from 'lucide-react';
+
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'https://mercasto.com/api';
+const STORAGE_URL = import.meta.env.VITE_STORAGE_URL || '/storage';
+
+function avatarUrl(path) {
+  if (!path) return null;
+  if (path.startsWith('http') || path.startsWith('data:')) return path;
+  return `${STORAGE_URL}/${path.replace(/^\//, '')}`;
+}
+
+function formatTime(dateStr) {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const sameDay = date.toDateString() === now.toDateString();
+  return sameDay
+    ? date.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' })
+    : date.toLocaleDateString('es-MX', { day: '2-digit', month: 'short' });
+}
+
+let _echoInstance = null;
+async function getEcho() {
+  if (_echoInstance) return _echoInstance;
+  const mod = await import('../../echo');
+  _echoInstance = mod.default;
+  return _echoInstance;
+}
+
+export default function MessagesScreen({ user }) {
+  const navigate = useNavigate();
+  const { userId: routeUserId } = useParams();
+  const [searchParams] = useSearchParams();
+  const adId = searchParams.get('ad_id');
+
+  const [conversations, setConversations] = useState([]);
+  const [loadingConversations, setLoadingConversations] = useState(true);
+  const [messages, setMessages] = useState([]);
+  const [loadingMessages, setLoadingMessages] = useState(false);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const bottomRef = useRef(null);
+  const token = localStorage.getItem('auth_token');
+
+  const selectedUserId = routeUserId ? Number(routeUserId) : null;
+  const selectedConversation = conversations.find(c => c.user_id === selectedUserId);
+
+  const loadConversations = useCallback(async () => {
+    if (!token) return;
+    setLoadingConversations(true);
+    try {
+      const res = await fetch(`${API_URL}/conversations`, { headers: { Authorization: `Bearer ${token}` } });
+      if (res.ok) setConversations(await res.json());
+    } catch { /* keep the screen quiet, retry on next visit */ }
+    finally { setLoadingConversations(false); }
+  }, [token]);
+
+  useEffect(() => { loadConversations(); }, [loadConversations]);
+
+  const loadMessages = useCallback(async (otherUserId) => {
+    if (!token || !otherUserId) return;
+    setLoadingMessages(true);
+    try {
+      const res = await fetch(`${API_URL}/conversations/${otherUserId}/messages`, { headers: { Authorization: `Bearer ${token}` } });
+      if (res.ok) {
+        setMessages(await res.json());
+        setConversations(prev => prev.map(c => c.user_id === otherUserId ? { ...c, unread_count: 0, is_read: true } : c));
+      }
+    } catch { /* keep the screen quiet */ }
+    finally { setLoadingMessages(false); }
+  }, [token]);
+
+  useEffect(() => {
+    if (selectedUserId) loadMessages(selectedUserId);
+    else setMessages([]);
+  }, [selectedUserId, loadMessages]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Real-time: nuevos mensajes entrantes mientras el hilo está abierto
+  useEffect(() => {
+    if (!user?.id) return undefined;
+    let cancelled = false;
+    let channel = null;
+    getEcho().then((echo) => {
+      if (cancelled || !echo) return;
+      if (token && echo.connector?.pusher?.config?.auth?.headers) {
+        echo.connector.pusher.config.auth.headers.Authorization = `Bearer ${token}`;
+      }
+      channel = echo.private(`chat.${user.id}`);
+      channel.listen('.message.sent', (e) => {
+        const incoming = e.message;
+        if (selectedUserId && incoming.sender_id === selectedUserId) {
+          setMessages(prev => [...prev, incoming]);
+        }
+        loadConversations();
+      });
+    });
+    return () => {
+      cancelled = true;
+      if (channel) channel.stopListening('.message.sent');
+    };
+  }, [user?.id, selectedUserId, token, loadConversations]);
+
+  const handleSend = async (e) => {
+    e.preventDefault();
+    const content = input.trim();
+    if (!content || sending || !selectedUserId) return;
+    setSending(true);
+    setInput('');
+    try {
+      const res = await fetch(`${API_URL}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ receiver_id: selectedUserId, content, ad_id: adId || undefined }),
+      });
+      if (res.ok) {
+        const sent = await res.json();
+        setMessages(prev => [...prev, sent]);
+        loadConversations();
+      } else {
+        setInput(content);
+      }
+    } catch {
+      setInput(content);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-slate-500">Inicia sesión para ver tus mensajes.</p>
+      </div>
+    );
+  }
+
+  const listPane = (
+    <div className={`w-full md:w-[340px] md:border-r border-slate-200 dark:border-slate-800 flex-shrink-0 ${selectedUserId ? 'hidden md:block' : 'block'}`}>
+      <div className="p-4 border-b border-slate-100 dark:border-slate-800">
+        <h1 className="text-[17px] font-bold text-slate-900 dark:text-white">Mensajes</h1>
+      </div>
+      <div className="overflow-y-auto" style={{ maxHeight: 'calc(100vh - 65px)' }}>
+        {loadingConversations ? (
+          <div className="p-8 text-center text-slate-400 text-[14px]">Cargando...</div>
+        ) : conversations.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 gap-3 px-6 text-center">
+            <MessageCircle className="w-10 h-10 text-slate-300" />
+            <p className="text-slate-500 dark:text-slate-300 text-[14px] font-medium">No tienes conversaciones todavía</p>
+            <p className="text-slate-400 dark:text-slate-500 text-[12px]">Cuando contactes o te contacten sobre un anuncio, aparecerá aquí.</p>
+          </div>
+        ) : (
+          conversations.map(c => (
+            <button
+              key={c.user_id}
+              onClick={() => navigate(`/mensajes/${c.user_id}`)}
+              className={`w-full text-left flex items-center gap-3 px-4 py-3 border-b border-slate-50 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors ${selectedUserId === c.user_id ? 'bg-slate-50 dark:bg-slate-800' : ''}`}
+            >
+              {avatarUrl(c.avatar_url) ? (
+                <img src={avatarUrl(c.avatar_url)} alt="" className="w-11 h-11 rounded-full object-cover flex-shrink-0" />
+              ) : (
+                <div className="w-11 h-11 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center text-slate-500 font-bold flex-shrink-0">
+                  {(c.name || '?')[0].toUpperCase()}
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between gap-2">
+                  <span className={`text-[14px] truncate ${!c.is_read ? 'font-bold text-slate-900 dark:text-white' : 'font-semibold text-slate-700 dark:text-slate-200'}`}>{c.name}</span>
+                  <span className="text-[11px] text-slate-400 flex-shrink-0">{formatTime(c.created_at)}</span>
+                </div>
+                {c.ad?.title && <p className="text-[11px] text-slate-400 truncate">{c.ad.title}</p>}
+                <p className={`text-[12px] truncate ${!c.is_read ? 'text-slate-700 dark:text-slate-200 font-medium' : 'text-slate-400'}`}>{c.last_message}</p>
+              </div>
+              {!c.is_read && c.unread_count > 0 && (
+                <span className="min-w-[18px] h-[18px] px-1 bg-[#84CC16] text-slate-950 text-[10px] font-bold rounded-full flex items-center justify-center flex-shrink-0">
+                  {c.unread_count > 9 ? '9+' : c.unread_count}
+                </span>
+              )}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
+  const threadPane = selectedUserId ? (
+    <div className="flex-1 flex flex-col min-w-0">
+      <div className="p-4 border-b border-slate-100 dark:border-slate-800 flex items-center gap-3 flex-shrink-0">
+        <button onClick={() => navigate('/mensajes')} className="md:hidden p-1 -ml-1 text-slate-500 hover:text-slate-900 dark:hover:text-white">
+          <ArrowLeft size={20} />
+        </button>
+        {avatarUrl(selectedConversation?.avatar_url) ? (
+          <img src={avatarUrl(selectedConversation.avatar_url)} alt="" className="w-9 h-9 rounded-full object-cover" />
+        ) : (
+          <div className="w-9 h-9 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center text-slate-500 font-bold text-[13px]">
+            {(selectedConversation?.name || '?')[0].toUpperCase()}
+          </div>
+        )}
+        <div className="min-w-0">
+          <p className="text-[14px] font-bold text-slate-900 dark:text-white truncate">{selectedConversation?.name || 'Usuario'}</p>
+          {selectedConversation?.ad?.title && <p className="text-[11px] text-slate-400 truncate">{selectedConversation.ad.title}</p>}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-2 bg-slate-50 dark:bg-slate-950">
+        {loadingMessages ? (
+          <div className="text-center text-slate-400 text-[13px] py-8">Cargando...</div>
+        ) : (
+          messages.map(m => {
+            const mine = m.sender_id === user.id;
+            return (
+              <div key={m.id} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
+                <div className={`max-w-[75%] px-3.5 py-2 rounded-2xl text-[14px] leading-snug ${mine ? 'bg-[#84CC16] text-slate-950 rounded-br-sm' : 'bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 rounded-bl-sm border border-slate-100 dark:border-slate-700'}`}>
+                  <p className="whitespace-pre-wrap break-words">{m.content}</p>
+                  <span className={`text-[10px] block mt-1 text-right ${mine ? 'text-slate-950/60' : 'text-slate-400'}`}>{formatTime(m.created_at)}</span>
+                </div>
+              </div>
+            );
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={handleSend} className="p-3 border-t border-slate-100 dark:border-slate-800 flex items-center gap-2 flex-shrink-0">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          maxLength={1000}
+          placeholder="Escribe un mensaje..."
+          className="flex-1 px-4 py-2.5 rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-[14px] outline-none focus:ring-2 focus:ring-[#84CC16]/30 focus:border-[#84CC16] text-slate-900 dark:text-white"
+        />
+        <button type="submit" disabled={sending || !input.trim()} className="w-10 h-10 rounded-full bg-[#84CC16] text-slate-950 flex items-center justify-center disabled:opacity-40 flex-shrink-0 hover:bg-[#65A30D] transition-colors">
+          <Send size={17} />
+        </button>
+      </form>
+    </div>
+  ) : (
+    <div className="hidden md:flex flex-1 items-center justify-center text-slate-400 text-[14px]">
+      Selecciona una conversación
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen flex bg-white dark:bg-slate-900" style={{ minHeight: 'calc(100vh - 0px)' }}>
+      {listPane}
+      {threadPane}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Discovered that a fully-built, production-quality in-app chat backend (`ChatController`, `Conversation`/`Message` models, `MessageSent` broadcast event, migrations) already existed in the codebase but was completely dark: no routes registered, no channel authorization for the private channel it broadcasts to, and zero frontend UI (the `MessageCircle` icon was already imported in `App.jsx` and never used). The only live buyer↔seller contact path was a one-shot email relay with no history.
- Wired it up end-to-end and fixed everything that broke when actually exercised live:
  - **Routes**: added `GET /conversations`, `GET /conversations/{id}/messages`, `POST /messages` (throttled 30/min/user) under `auth:sanctum`.
  - **Channel auth**: `routes/channels.php` never authorized `chat.{id}` — the exact channel `MessageSent` broadcasts to — so every real-time delivery would have been silently rejected by Reverb/Pusher.
  - **DB bug**: `sendMessage()` never populated `messages.receiver_id`/`messages.content`, both `NOT NULL` legacy columns predating the conversations schema — every message insert threw a constraint violation. Fixed by populating them (didn't add a nullable-column migration since `doctrine/dbal` isn't installed, so `Schema::table()->change()` isn't available in this app).
  - **Duplicate-conversation bug**: buyer/seller roles were derived from who was sending vs. receiving on each call instead of a stable per-pair identity, so any reply without an `ad_id` created a brand new `Conversation` row instead of continuing the thread. Now reuses the existing conversation between the two users first.
  - **Query bug**: `getConversations()`'s column-restricted eager load on the `latestOfMany()` relation collided with that relation's own subquery column ("ambiguous column name"). Loads unrestricted now.
- New frontend `MessagesScreen` (conversation list + thread, mobile list↔thread swap / desktop side-by-side), real-time via the same Echo/Reverb pattern already used for notifications, an unread-messages badge in the header + mobile menu, and a new "Mensaje por Mercasto" option in `ContactButton` (in-app, no reload) alongside the existing WhatsApp/Telegram/phone/email channels.

## Agent owner

- Claude Code

## Risk level

- [ ] Low: docs/copy/non-runtime
- [x] Medium: UI/backend behavior but no sensitive areas
- [ ] High: auth/payments/uploads/database/infra/security
- [ ] Critical: production/secrets/destructive operations

## Two-step critique

### Critique 1: risk and correctness

New routes are all scoped to `auth:sanctum` and every read is filtered by the authenticated user's own `buyer_id`/`seller_id` membership — verified with a test that an outsider gets zero messages back from someone else's conversation. No existing endpoint, table, or behavior was changed; this is purely additive (new routes, new channel authorization rule, one new frontend screen, one new option in an existing modal). The three backend bugs fixed were in code that was never live (unreachable without routes), so there's no risk of this changing already-working behavior — it's the first time this code path has ever executed outside my testing.

### Critique 2: alternatives and quality

Considered leaving `messages.receiver_id`/`content` unpopulated and instead migrating them to nullable, which is arguably the "cleaner" schema — but that requires `Schema::table()->change()`, which needs `doctrine/dbal` (not installed), and adding a new Composer dependency for this felt like more infra risk than just keeping two legacy columns in sync with their replacements, especially since `Message::getContentAttribute()`/`getBodyAttribute()` already treat them as mirrors of each other by design. Considered making the internal-message option replace WhatsApp/Telegram as the primary CTA, but kept all existing channels intact and just added this as a new, first-listed option — sellers who rely on WhatsApp today aren't disrupted.

## Changed areas

- [x] Frontend
- [x] Backend/API
- [ ] Database
- [ ] Docker/infra
- [ ] Security/auth
- [ ] Payments/Clip
- [ ] AI/ML
- [ ] SEO/content
- [ ] Documentation only

## Smoke tests

- `npm run build`, `npx eslint src/App.jsx src/components/screens/MessagesScreen.jsx src/components/common/ContactButton.jsx --quiet` — clean.
- `php -l` on all changed/new PHP files — no syntax errors.
- `bash scripts/attribute-flow-gate.sh`, `bash scripts/auth-account-gate.sh` — OK.
- Full backend PHPUnit suite: `./vendor/bin/phpunit` — **15/15 passing**, including 4 new `ChatControllerTest` cases covering the exact bugs found (conversation creation + delivery, dedup across replies without `ad_id`, ad-scoped conversations, cross-user read isolation).
- **Full live end-to-end verification**, not just unit tests: stood up a real local backend (`composer install`, migrated + seeded, `php artisan reverb:start`) and the real frontend dev server, logged into two separate browser contexts as two different seeded users, and confirmed via the actual UI: messages send and persist, three back-and-forth replies without `ad_id` correctly stay in **one** conversation (not three), the conversation list and unread badges update correctly, and a message sent in one browser tab **appears in the other tab in real time with no reload** (screenshots taken before/after). Also clicked through from a real ad detail page → "Mensaje por Mercasto" → confirmed it deep-links into `/mensajes/{sellerId}?ad_id={id}`.

## Rollback plan

- Revert this PR / redeploy the previous commit. No destructive migrations — `routes/channels.php` and `routes/api.php` changes are purely additive route/channel registrations with no schema impact, and no existing table or column was altered.

## Human approval needed?

- [ ] No
- [x] Yes — this is a large-ish UI addition (new screen + new nav entry points) and I'd like a look before it ships, even though nothing here touches auth/payments/security boundaries.

## Screenshots / evidence

- Two-browser real-time test: seller's view showing 3 messages sent/received, and admin's view showing the same thread with the live-delivered message appearing with no page reload.
- `ContactButton` modal on a real ad detail page showing the new "Mensaje por Mercasto" option as the first, most prominent contact channel.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe6oYZEPNe3yapXvyp3UDP)_