### PR TITLE
Fix Spanish language for seller campaign landing

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,10 +4,35 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 
 import es from './locales/es.json';
 
+const normalizePathname = (pathname = '') => {
+  const trimmed = String(pathname).replace(/^\/+|\/+$/g, '');
+  return trimmed ? `/${trimmed}` : '/';
+};
+
+const SPANISH_CAMPAIGN_PATHS = new Set(['/vendedores', '/publicar-gratis']);
+const forceSpanishCampaignLanding =
+  typeof window !== 'undefined' &&
+  SPANISH_CAMPAIGN_PATHS.has(normalizePathname(window.location.pathname));
+
+// Paid traffic to the seller landing must always start in Spanish, regardless
+// of a previously saved language or the browser/device language.
+if (forceSpanishCampaignLanding) {
+  try {
+    localStorage.setItem('lang', 'es');
+    localStorage.setItem('mercasto_language', 'es');
+  } catch {}
+
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = 'es';
+    document.documentElement.dir = 'ltr';
+  }
+}
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    ...(forceSpanishCampaignLanding ? { lng: 'es' } : {}),
     resources: {
       es: { translation: es }
     },

--- a/tests/e2e/seller-landing-language.spec.js
+++ b/tests/e2e/seller-landing-language.spec.js
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('seller campaign landing language', () => {
+  test.use({ locale: 'ru-RU' });
+
+  test('forces Spanish despite saved and browser language', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('lang', 'ru');
+      localStorage.setItem('mercasto_language', 'ru');
+    });
+
+    const response = await page.goto('/vendedores', { waitUntil: 'domcontentloaded' });
+
+    expect(response?.status(), '/vendedores HTTP status').toBeLessThan(400);
+    await expect(page.locator('body')).toContainText('Vende más rápido');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'es');
+
+    await expect.poll(() => page.evaluate(() => ({
+      appLanguage: localStorage.getItem('lang'),
+      detectedLanguage: localStorage.getItem('mercasto_language'),
+    }))).toEqual({
+      appLanguage: 'es',
+      detectedLanguage: 'es',
+    });
+  });
+});


### PR DESCRIPTION
## Что изменено

- `/vendedores` и `/publicar-gratis` принудительно запускаются на испанском языке при прямом переходе.
- Значения `lang` и `mercasto_language` синхронизируются в `localStorage` до первого рендера React.
- i18next получает `es` до определения языка браузера/телефона, поэтому не возникает первоначального показа русского, английского или другого языка.
- После загрузки пользователь по-прежнему может вручную переключить язык обычным селектором.

## Проверка

Добавлен Playwright-сценарий: браузер `ru-RU`, оба сохранённых значения языка — `ru`, но `/vendedores` отображается на испанском, `<html lang="es">`, а оба значения в хранилище становятся `es`.

## Причина

Рекламные объявления Meta ведут на `https://mercasto.com/vendedores`. Эта страница должна открываться на испанском независимо от языка устройства и ранее сохранённых настроек сайта.