### PR TITLE
Fix Meta Pixel in production frontend build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ PORT=5000
 # GEMINI_API_KEY=ya29....
 
 # Marketing analytics / pixels
-# Keep empty to disable a vendor. IDs are public tag identifiers, not API secrets.
+# IDs are public tag identifiers, not API secrets. Set VITE_ANALYTICS_ENABLED=false to disable browser analytics.
 VITE_ANALYTICS_ENABLED=true
 VITE_ANALYTICS_VERBOSE=false
-VITE_META_PIXEL_ID=
+VITE_META_PIXEL_ID=4595315270748335
 VITE_MICROSOFT_UET_TAG_ID=
 VITE_CLARITY_PROJECT_ID=
 
@@ -23,7 +23,6 @@ FACEBOOK_TEST_EVENT_CODE=
 # Grafana monitoring dashboard (only used with --profile monitoring)
 GRAFANA_PASSWORD=
 
-# Laravel Echo / Reverb WebSocket (for frontend)
 VITE_REVERB_APP_KEY=
 VITE_REVERB_HOST=mercasto.com
 VITE_REVERB_PORT=443

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ COPY . .
 RUN npm run build
 
 # Fail the image build if the production bundle silently loses Meta Pixel again.
-RUN grep -R --fixed-strings "4595315270748335" /app/dist/assets >/dev/null \
-    && grep -R --fixed-strings "connect.facebook.net/en_US/fbevents.js" /app/dist/assets >/dev/null
+# Use BusyBox-compatible short grep flags because the build image is Alpine.
+RUN grep -R -F "4595315270748335" /app/dist/assets >/dev/null \
+    && grep -R -F "connect.facebook.net/en_US/fbevents.js" /app/dist/assets >/dev/null
 
 # --- Этап раздачи (Serve Stage) ---
 FROM nginx:stable-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ FROM node:22-alpine AS build
 
 WORKDIR /app
 
+# Public analytics identifiers must exist while Vite builds the frontend bundle.
+# They can still be overridden with Docker build args when needed.
+ARG VITE_ANALYTICS_ENABLED=true
+ARG VITE_META_PIXEL_ID=4595315270748335
+ENV VITE_ANALYTICS_ENABLED=${VITE_ANALYTICS_ENABLED}
+ENV VITE_META_PIXEL_ID=${VITE_META_PIXEL_ID}
+
 # Копируем package.json/package-lock.json и устанавливаем зависимости воспроизводимо.
 COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
@@ -11,6 +18,10 @@ RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 # Копируем остальные файлы и собираем production-версию
 COPY . .
 RUN npm run build
+
+# Fail the image build if the production bundle silently loses Meta Pixel again.
+RUN grep -R --fixed-strings "4595315270748335" /app/dist/assets >/dev/null \
+    && grep -R --fixed-strings "connect.facebook.net/en_US/fbevents.js" /app/dist/assets >/dev/null
 
 # --- Этап раздачи (Serve Stage) ---
 FROM nginx:stable-alpine


### PR DESCRIPTION
## Summary

- Production Docker-сборка теперь всегда получает `VITE_META_PIXEL_ID=4595315270748335` до запуска Vite.
- `VITE_ANALYTICS_ENABLED` явно включён на этапе сборки.
- Значения можно переопределить через Docker build args.
- После `npm run build` Docker проверяет, что готовый bundle содержит Pixel ID и загрузчик `fbevents.js`.
- Проверка использует совместимые с Alpine/BusyBox короткие флаги `grep -R -F`.
- `.env.example` синхронизирован с действующим Pixel ID.

## Risk

Низкий. Изменения затрагивают только параметры frontend-сборки и проверку готового bundle. Pixel ID является публичным идентификатором, не секретом. Если Meta Pixel будет заблокирован браузером или расширением, сайт продолжит работать.

## Smoke

- Обычная frontend-сборка в GitHub Actions проходит.
- Docker image должен успешно собраться на Alpine.
- Во время Docker build проверяется наличие `4595315270748335` и `connect.facebook.net/en_US/fbevents.js` в `dist/assets`.
- После деплоя проверить в Meta Events Manager или Meta Pixel Helper событие `PageView` на `https://mercasto.com/vendedores`.

## Rollback

Откатить squash-коммит этого PR либо удалить `ARG/ENV VITE_META_PIXEL_ID` и две команды проверки из Dockerfile, затем пересобрать frontend image.