### PR TITLE
Verify Meta Pixel in production deployments

### DIFF
--- a/.github/workflows/deploy-selfhosted.yml
+++ b/.github/workflows/deploy-selfhosted.yml
@@ -53,7 +53,7 @@ jobs:
             UP_SERVICES="mercasto-frontend mercasto-backend mercasto-worker mercasto-scheduler mercasto-reverb"
           else
             echo "$CHANGED_FILES"
-            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(Dockerfile|src/|public/|index.html|package\.json|package-lock\.json|vite\.config|tailwind\.config|postcss\.config|default\.conf)'; then
+            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(Dockerfile|src/|public/|index.html|package\.json|package-lock\.json|vite\.config|tailwind\.config|postcss\.config|default\.conf|\.github/workflows/deploy-selfhosted\.yml$)'; then
               add_service mercasto-frontend
               UP_SERVICES="$UP_SERVICES mercasto-frontend"
             fi
@@ -105,6 +105,25 @@ jobs:
           done
 
           curl -fsS --max-time 10 https://mercasto.com/api/auth/providers >/dev/null
+
+      - name: Verify deployed Meta Pixel
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd /var/www/mercasto
+
+          docker compose --env-file backend/.env exec -T -e DEPLOY_SHA="$DEPLOY_SHA" mercasto-frontend sh -lc '
+            grep -R -F "4595315270748335" /usr/share/nginx/html/assets >/dev/null
+            grep -R -F "connect.facebook.net/en_US/fbevents.js" /usr/share/nginx/html/assets >/dev/null
+            printf '\''{"pixel_id":"4595315270748335","bundle_verified":true,"commit":"%s"}\n'\'' "$DEPLOY_SHA" > /usr/share/nginx/html/meta-pixel-status.json
+          '
+
+          STATUS_JSON="$(curl -fsS --max-time 15 "https://mercasto.com/meta-pixel-status.json?sha=${DEPLOY_SHA}")"
+          printf '%s\n' "$STATUS_JSON"
+          printf '%s' "$STATUS_JSON" | grep -F '"pixel_id":"4595315270748335"' >/dev/null
+          printf '%s' "$STATUS_JSON" | grep -F '"bundle_verified":true' >/dev/null
+          printf '%s' "$STATUS_JSON" | grep -F "\"commit\":\"${DEPLOY_SHA}\"" >/dev/null
 
       - name: Production smoke
         run: |


### PR DESCRIPTION
## Summary

- Uses the existing automatic `Deploy Mercasto` workflow that already runs on every push to `main`.
- Makes changes to `deploy-selfhosted.yml` trigger a frontend rebuild, so merging this PR will redeploy the Pixel fix immediately.
- Verifies the running frontend container contains Pixel ID `4595315270748335` and the Meta `fbevents.js` loader.
- Writes a public `meta-pixel-status.json` only after those checks pass, including the deployed commit SHA.
- Fetches that status through `https://mercasto.com` and validates the Pixel ID, verification flag, and commit SHA before the deployment can succeed.

## Risk

Low. The application code and backend are unchanged. The workflow rebuilds and restarts only the frontend for this change. If the running bundle lacks Meta Pixel, deployment is marked failed rather than falsely reporting success; the existing recovery step keeps containers running.

## Smoke

- GitHub PR quality and production checks must pass.
- On merge, `Deploy Mercasto` rebuilds `mercasto-frontend` because the workflow file itself is now part of the frontend rebuild matcher.
- The deploy fails unless the running container contains both the Pixel ID and `connect.facebook.net/en_US/fbevents.js`.
- The deploy also fails unless the public status JSON contains the exact merge commit SHA.

## Rollback

Revert this PR. That removes the post-deploy Pixel verification and restores the previous frontend change matcher; the existing application and Docker Pixel configuration remain unchanged.