### PR TITLE
Install TikTok Pixel

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,12 +7,14 @@ import { UIProvider } from './contexts/UIContext.jsx'
 import { ToastProvider } from './components/ui/Toast.jsx'
 import { initBehaviorAnalytics } from './utils/analytics'
 import { installMetaCapiBridge } from './utils/metaCapiBridge'
+import { initTikTokPixel } from './utils/tiktokPixel'
 // Leaflet CSS is loaded lazily alongside the map bundle (see MapV3 loadLeaflet)
 // so it no longer bloats the render-blocking critical stylesheet.
 import './index.css'
 import './i18n'; // Multi-language support
 
 installMetaCapiBridge();
+initTikTokPixel();
 initBehaviorAnalytics();
 
 const rootElement = document.getElementById('root');

--- a/src/utils/tiktokPixel.js
+++ b/src/utils/tiktokPixel.js
@@ -1,0 +1,56 @@
+const TIKTOK_PIXEL_ID = 'D9C3HKBC77UBS5FSD7C0';
+
+export function initTikTokPixel() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (window.__mercastoTikTokPixelLoaded) return;
+
+  window.__mercastoTikTokPixelLoaded = true;
+
+  /* eslint-disable */
+  !function (w, d, t) {
+    w.TiktokAnalyticsObject = t;
+    var ttq = w[t] = w[t] || [];
+    ttq.methods = [
+      'page', 'track', 'identify', 'instances', 'debug', 'on', 'off', 'once',
+      'ready', 'alias', 'group', 'enableCookie', 'disableCookie', 'holdConsent',
+      'revokeConsent', 'grantConsent'
+    ];
+    ttq.setAndDefer = function (target, method) {
+      target[method] = function () {
+        target.push([method].concat(Array.prototype.slice.call(arguments, 0)));
+      };
+    };
+    for (var i = 0; i < ttq.methods.length; i++) {
+      ttq.setAndDefer(ttq, ttq.methods[i]);
+    }
+    ttq.instance = function (pixelId) {
+      var instance = ttq._i[pixelId] || [];
+      for (var j = 0; j < ttq.methods.length; j++) {
+        ttq.setAndDefer(instance, ttq.methods[j]);
+      }
+      return instance;
+    };
+    ttq.load = function (pixelId, options) {
+      var url = 'https://analytics.tiktok.com/i18n/pixel/events.js';
+      var partner = options && options.partner;
+      ttq._i = ttq._i || {};
+      ttq._i[pixelId] = [];
+      ttq._i[pixelId]._u = url;
+      ttq._t = ttq._t || {};
+      ttq._t[pixelId] = +new Date();
+      ttq._o = ttq._o || {};
+      ttq._o[pixelId] = options || {};
+      var script = d.createElement('script');
+      script.type = 'text/javascript';
+      script.async = true;
+      script.src = url + '?sdkid=' + pixelId + '&lib=' + t;
+      var firstScript = d.getElementsByTagName('script')[0];
+      firstScript.parentNode.insertBefore(script, firstScript);
+      return partner;
+    };
+  }(window, document, 'ttq');
+  /* eslint-enable */
+
+  window.ttq.load(TIKTOK_PIXEL_ID);
+  window.ttq.page();
+}


### PR DESCRIPTION
## Summary

- Add the TikTok Pixel loader for Pixel ID `D9C3HKBC77UBS5FSD7C0`.
- Initialize it once when the Mercasto frontend starts.
- Send the initial TikTok `PageView` via `ttq.page()`.
- Keep the existing Meta Pixel and analytics integrations unchanged.

## Risk

Low. This adds one asynchronous third-party analytics script and does not affect payments, authentication, ads, or backend behavior.

## Smoke

- Confirm the production frontend bundle contains `D9C3HKBC77UBS5FSD7C0`.
- Open Mercasto and verify a request to `analytics.tiktok.com/i18n/pixel/events.js`.
- Confirm TikTok Events Manager receives `PageView`.

## Rollback

Revert this pull request to remove the TikTok loader and startup initialization.