### PR TITLE
Add TikTok identify and standard events

### DIFF
--- a/src/utils/tiktokPixel.js
+++ b/src/utils/tiktokPixel.js
@@ -1,7 +1,240 @@
 const TIKTOK_PIXEL_ID = 'D9C3HKBC77UBS5FSD7C0';
 
+const TIKTOK_EVENT_MAP = {
+  ad_viewed: 'ViewContent',
+  view_item: 'ViewContent',
+  select_content: 'ViewContent',
+  search: 'Search',
+  view_search_results: 'Search',
+  ui_click: 'ClickButton',
+  link_click: 'ClickButton',
+  form_submit_click: 'ClickButton',
+  form_submit: 'ClickButton',
+  ad_card_click: 'ClickButton',
+  contact_click: 'ClickButton',
+  whatsapp_click: 'ClickButton',
+  telegram_click: 'ClickButton',
+  phone_click: 'ClickButton',
+  email_click: 'ClickButton',
+  message_started: 'ClickButton',
+  favorite_added: 'ClickButton',
+  add_to_wishlist: 'ClickButton',
+  lead: 'Lead',
+  offer_made: 'Lead',
+  ad_posted: 'Lead',
+  listing_published: 'Lead',
+  sign_up: 'Lead',
+  phone_verified: 'Lead',
+};
+
+const AUTH_ENDPOINTS = new Set([
+  '/api/user',
+  '/api/login',
+  '/api/register',
+  '/api/two-factor/verify',
+]);
+
+function isBrowser() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function cleanString(value, maxLength = 200) {
+  if (value === undefined || value === null) return '';
+  return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function positiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : undefined;
+}
+
+function compactObject(object) {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => (
+      value !== undefined && value !== null && value !== ''
+    )),
+  );
+}
+
+async function sha256(value) {
+  if (!isBrowser() || !window.crypto?.subtle || !value) return '';
+  const bytes = new TextEncoder().encode(String(value));
+  const digest = await window.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function normalizeEmail(email) {
+  return cleanString(email, 320).toLowerCase();
+}
+
+function normalizePhone(phone) {
+  const raw = cleanString(phone, 80);
+  if (!raw) return '';
+  const digits = raw.replace(/\D/g, '');
+  if (!digits) return '';
+  return raw.startsWith('+') ? `+${digits}` : digits;
+}
+
+function normalizeExternalId(externalId) {
+  return cleanString(externalId, 200).toLowerCase();
+}
+
+export async function identifyTikTokUser(user = {}) {
+  if (!isBrowser() || typeof window.ttq?.identify !== 'function') return;
+
+  const email = normalizeEmail(user.email);
+  const phone = normalizePhone(user.phone_number || user.phone || user.telephone);
+  const externalId = normalizeExternalId(user.external_id || user.id || user.user_id);
+
+  const [hashedEmail, hashedPhone, hashedExternalId] = await Promise.all([
+    sha256(email),
+    sha256(phone),
+    sha256(externalId),
+  ]);
+
+  const identity = compactObject({
+    email: hashedEmail,
+    phone_number: hashedPhone,
+    external_id: hashedExternalId,
+  });
+
+  if (!Object.keys(identity).length) return;
+
+  const signature = JSON.stringify(identity);
+  if (window.__mercastoTikTokIdentitySignature === signature) return;
+  window.__mercastoTikTokIdentitySignature = signature;
+  window.ttq.identify(identity);
+}
+
+function buildContents(eventName, data) {
+  const contentId = cleanString(
+    data.content_id || data.ad_id || data.store_id || data.element_id || data.page_path,
+    180,
+  );
+  const contentName = cleanString(
+    data.content_name || data.item_name || data.element_text || data.page_title,
+    200,
+  );
+  const contentCategory = cleanString(
+    data.content_category || data.category || data.route_group,
+    120,
+  );
+  const price = positiveNumber(data.price ?? data.item_price ?? data.unit_price);
+  const numItems = positiveNumber(data.num_items ?? data.quantity);
+  const brand = cleanString(data.brand, 120);
+
+  const content = compactObject({
+    content_id: contentId,
+    content_type: data.content_type === 'product_group' || eventName === 'Search'
+      ? 'product_group'
+      : 'product',
+    content_name: contentName,
+    content_category: contentCategory,
+    price,
+    num_items: numItems,
+    brand,
+  });
+
+  return Object.keys(content).length > 1 ? [content] : undefined;
+}
+
+async function createEventId(data) {
+  const seed = cleanString(data.event_id, 240)
+    || `${Date.now()}_${window.crypto?.randomUUID?.() || Math.random().toString(16).slice(2)}`;
+  return sha256(seed);
+}
+
+async function trackTikTokEvent(eventName, data = {}) {
+  if (!isBrowser() || typeof window.ttq?.track !== 'function') return;
+
+  const value = positiveNumber(data.value ?? data.event_value ?? data.price);
+  const description = cleanString(data.content_description || data.public_description, 240);
+  const payload = compactObject({
+    contents: buildContents(eventName, data),
+    value,
+    currency: cleanString(data.currency || 'MXN', 8).toUpperCase(),
+    search_string: cleanString(data.search_string || data.search_term, 200),
+    // Browser IP is already available to TikTok from the request. Never place raw PII in description.
+    description: description && description !== '[redacted]' ? description : undefined,
+    status: cleanString(data.status, 80),
+  });
+
+  const eventId = await createEventId(data);
+  window.ttq.track(eventName, payload, eventId ? { event_id: eventId } : undefined);
+}
+
+function handleDataLayerItem(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return;
+  const analyticsEvent = cleanString(item.event, 80).toLowerCase();
+  if (!analyticsEvent) return;
+
+  if (analyticsEvent === 'page_view') {
+    const pageKey = cleanString(
+      item.page_path || `${window.location.pathname}${window.location.search}${window.location.hash}`,
+      500,
+    );
+    if (pageKey && pageKey !== window.__mercastoTikTokLastPageKey) {
+      window.__mercastoTikTokLastPageKey = pageKey;
+      window.ttq.page();
+    }
+    return;
+  }
+
+  const tikTokEvent = TIKTOK_EVENT_MAP[analyticsEvent];
+  if (!tikTokEvent) return;
+  trackTikTokEvent(tikTokEvent, item).catch(() => {});
+}
+
+function installDataLayerBridge() {
+  if (!isBrowser() || window.__mercastoTikTokDataLayerBridgeInstalled) return;
+  window.__mercastoTikTokDataLayerBridgeInstalled = true;
+  window.dataLayer = window.dataLayer || [];
+
+  const dataLayer = window.dataLayer;
+  const originalPush = dataLayer.push.bind(dataLayer);
+  dataLayer.push = function patchedTikTokDataLayerPush(...items) {
+    const result = originalPush(...items);
+    items.forEach(handleDataLayerItem);
+    return result;
+  };
+
+  dataLayer.forEach(handleDataLayerItem);
+}
+
+function extractRequestPath(input) {
+  try {
+    const rawUrl = typeof input === 'string' || input instanceof URL
+      ? String(input)
+      : input?.url;
+    return new URL(rawUrl, window.location.origin).pathname;
+  } catch {
+    return '';
+  }
+}
+
+function installAuthIdentityBridge() {
+  if (!isBrowser() || window.__mercastoTikTokAuthBridgeInstalled) return;
+  window.__mercastoTikTokAuthBridgeInstalled = true;
+
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async function patchedTikTokIdentityFetch(input, init) {
+    const response = await originalFetch(input, init);
+    const path = extractRequestPath(input);
+
+    if (response.ok && AUTH_ENDPOINTS.has(path)) {
+      response.clone().json()
+        .then((data) => identifyTikTokUser(data?.user || data))
+        .catch(() => {});
+    }
+
+    return response;
+  };
+}
+
 export function initTikTokPixel() {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (!isBrowser()) return;
   if (window.__mercastoTikTokPixelLoaded) return;
 
   window.__mercastoTikTokPixelLoaded = true;
@@ -52,5 +285,8 @@ export function initTikTokPixel() {
   /* eslint-enable */
 
   window.ttq.load(TIKTOK_PIXEL_ID);
+  window.__mercastoTikTokLastPageKey = `${window.location.pathname}${window.location.search}${window.location.hash}`;
   window.ttq.page();
+  installDataLayerBridge();
+  installAuthIdentityBridge();
 }


### PR DESCRIPTION
## Summary

- Add SHA-256 TikTok `identify` for authenticated users using email, phone and internal user ID when available.
- Read identity only from successful Mercasto auth responses (`/api/user`, login, registration and 2FA); raw PII is never sent to TikTok.
- Bridge Mercasto's existing analytics `dataLayer` to TikTok standard events: `ViewContent`, `Search`, `ClickButton` and `Lead`.
- Include real content IDs, names, categories, prices, item counts, brands, value, MXN currency, search strings and status when available.
- Generate a SHA-256 event ID for every TikTok event.
- Track SPA page changes without duplicating the initial `PageView`.
- Do not place browser IP or raw PII into the `description` field.

## Risk

Low to medium. This changes only browser analytics. Authentication responses are cloned read-only and the original fetch response is returned unchanged. TikTok failures cannot block login, registration, navigation or marketplace actions.

## Smoke

- Run frontend lint and production build.
- Confirm the bundle contains `identifyTikTokUser`, `ViewContent`, `Search`, `ClickButton`, `Lead` and Pixel ID `D9C3HKBC77UBS5FSD7C0`.
- Log in and verify `ttq.identify` receives only 64-character SHA-256 values.
- Open an ad, search, click a tracked button and publish/contact to confirm the four standard events.
- Confirm raw email and phone are absent from TikTok requests.

## Rollback

Revert this pull request to return to base TikTok `PageView` tracking only.