### PR TITLE
Use protected env in production smoke

### DIFF
--- a/.github/workflows/deploy-selfhosted.yml
+++ b/.github/workflows/deploy-selfhosted.yml
@@ -174,14 +174,17 @@ jobs:
       - name: Production smoke
         run: |
           cd /var/www/mercasto
+          COMPOSE_ENV_FILE="$RUNNER_TEMP/mercasto-backend.env"
+          test -s "$COMPOSE_ENV_FILE"
+
           for attempt in 1 2 3; do
-            if SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh; then
+            if COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh; then
               exit 0
             fi
             echo "production smoke failed, retrying in 20s ($attempt/3)" >&2
             sleep 20
           done
-          SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
+          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
 
       - name: Recovery on failure
         if: failure()


### PR DESCRIPTION
## Summary

- Pass the runner-private Compose env file into `scripts/production-smoke.sh`.
- Keep the persistent `backend/.env` root-only.
- Validate the temporary file before running smoke checks.

## Risk

Low. This changes only which env-file path the existing smoke script reads. No application code or production configuration values are changed.

## Smoke

- Run PR quality and production safety checks.
- Merge and confirm the deploy build, Pixel verification, and full production smoke all pass.

## Rollback

Revert this pull request to restore the previous smoke invocation, which will fail while `backend/.env` remains root-only.