### PR TITLE
Report TikTok verification transport errors

### DIFF
--- a/backend/app/Console/Commands/VerifyTikTokEventsApi.php
+++ b/backend/app/Console/Commands/VerifyTikTokEventsApi.php
@@ -42,11 +42,16 @@ class VerifyTikTokEventsApi extends Command
         );
 
         if (! ($result['ok'] ?? false)) {
+            $detail = $result['message']
+                ?? $result['reason']
+                ?? $result['error']
+                ?? 'unknown';
+
             $this->error(sprintf(
                 'TikTok Events API rejected verification (HTTP %s, code %s, message %s).',
                 $result['status'] ?? 'n/a',
                 $result['code'] ?? 'n/a',
-                $result['message'] ?? $result['reason'] ?? 'unknown'
+                mb_substr((string) $detail, 0, 300)
             ));
 
             return self::FAILURE;


### PR DESCRIPTION
## Summary

- Include the caught transport/SSL exception text in the sanitized TikTok verification result when no HTTP response exists.
- Keep the output bounded and passed through the existing deployment sanitizer.
- Do not log or expose request headers, access tokens, or payload contents.

## Risk

Low. This changes only diagnostic output from the technical verification command. TikTok event delivery behavior is unchanged.

## Smoke

- Run backend PHPUnit and workflow checks.
- Merge and confirm production status distinguishes DNS, TLS, timeout, configuration, and API-response failures.
- Confirm no credential appears in the status result.

## Rollback

Revert this pull request to return to the generic `message unknown` result for transport failures.