### PR TITLE
Print TikTok verification errors as plain text

### DIFF
--- a/backend/app/Console/Commands/VerifyTikTokEventsApi.php
+++ b/backend/app/Console/Commands/VerifyTikTokEventsApi.php
@@ -46,18 +46,19 @@ class VerifyTikTokEventsApi extends Command
                 ?? $result['reason']
                 ?? $result['error']
                 ?? 'unknown';
-
-            $this->error(sprintf(
+            $message = sprintf(
                 'TikTok Events API rejected verification (HTTP %s, code %s, message %s).',
                 $result['status'] ?? 'n/a',
                 $result['code'] ?? 'n/a',
-                mb_substr((string) $detail, 0, 300)
-            ));
+                preg_replace('/\s+/', ' ', mb_substr((string) $detail, 0, 300))
+            );
+
+            fwrite(STDERR, $message . PHP_EOL);
 
             return self::FAILURE;
         }
 
-        $this->info('TikTok Events API accepted the verification event.');
+        fwrite(STDOUT, 'TikTok Events API accepted the verification event.' . PHP_EOL);
 
         return self::SUCCESS;
     }


### PR DESCRIPTION
## Summary

- Print TikTok verification success and failure as plain one-line stdout/stderr messages.
- Remove Symfony console decoration that split the sanitized result across multiple lines.
- Preserve bounded transport/API detail without exposing headers, tokens, or payloads.

## Risk

Low. Only diagnostic console formatting changes; event delivery is unchanged.

## Smoke

- Run PHPUnit and repository checks.
- Merge and confirm the production status contains the full sanitized transport or API result.

## Rollback

Revert this pull request to restore decorated Artisan error output.