### PR TITLE
Parse TikTok API error responses

### DIFF
--- a/backend/app/Services/TikTokEventsApiService.php
+++ b/backend/app/Services/TikTokEventsApiService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -96,6 +97,32 @@ class TikTokEventsApiService
                 'message' => is_array($body) ? ($body['message'] ?? null) : null,
                 'event_id' => $normalizedEventId,
                 'body' => $body,
+            ];
+        } catch (RequestException $e) {
+            $response = $e->response;
+            $body = $response->json();
+            $code = is_array($body) ? ($body['code'] ?? null) : null;
+            $message = is_array($body)
+                ? ($body['message'] ?? $body['msg'] ?? null)
+                : null;
+
+            Log::warning('TikTok Events API rejected request', [
+                'event_name' => $eventName,
+                'event_id' => $normalizedEventId,
+                'status' => $response->status(),
+                'code' => $code,
+                'message' => $message,
+                'request_id' => is_array($body) ? ($body['request_id'] ?? data_get($body, 'data.request_id')) : null,
+            ]);
+
+            return [
+                'ok' => false,
+                'status' => $response->status(),
+                'code' => $code,
+                'message' => $message,
+                'event_id' => $normalizedEventId,
+                'body' => $body,
+                'error' => $e->getMessage(),
             ];
         } catch (\Throwable $e) {
             Log::error('TikTok Events API failed', [


### PR DESCRIPTION
## Summary

- Catch Laravel `RequestException` separately from transport failures.
- Read TikTok's HTTP status, API code, message, and request ID from the JSON response body.
- Keep access tokens, headers, and request payloads out of logs and deployment status.

## Risk

Low. Successful event delivery is unchanged. Failed HTTP responses now retain structured diagnostics instead of becoming generic exceptions.

## Smoke

- Run TikTok service tests and the full backend PHPUnit gate.
- Merge and confirm production verification reports TikTok's exact 401 message for code 40105.
- Confirm no credential appears in logs or status metadata.

## Rollback

Revert this pull request to return to generic HTTP exception diagnostics.