### PR TITLE
Skip generic onboarding for seller campaign registrations

### DIFF
--- a/src/utils/protectedRouteReturn.js
+++ b/src/utils/protectedRouteReturn.js
@@ -1,6 +1,8 @@
 const INTENT_STORAGE_KEY = 'mercasto.protected_route_intent.v1';
 const AUTH_TOKEN_KEY = 'auth_token';
 const USER_STORAGE_KEY = 'user';
+const REGISTRATION_FLAG_KEY = 'just_registered';
+const STORAGE_PATCH_MARKER = '__mercastoProtectedPostReturn';
 const INTENT_TTL_MS = 30 * 60 * 1000;
 const AUTH_SETTLE_MS = 150;
 const POLL_INTERVAL_MS = 50;
@@ -93,6 +95,36 @@ function readIntent() {
   }
 }
 
+function installRegistrationOnboardingBypass() {
+  if (typeof Storage === 'undefined') return;
+
+  const currentSetItem = Storage.prototype.setItem;
+  if (currentSetItem?.[STORAGE_PATCH_MARKER]) return;
+
+  function protectedRouteSetItem(key, value) {
+    let isLocalStorage = false;
+    try {
+      isLocalStorage = this === window.localStorage;
+    } catch {
+      // Fall through to the native implementation.
+    }
+
+    // The generic onboarding is useful for organic registrations, but it
+    // blocks the paid seller flow after the visitor has explicitly chosen to
+    // publish. Suppress only that one flag while a valid /post intent exists.
+    if (isLocalStorage && key === REGISTRATION_FLAG_KEY && readIntent()) {
+      return undefined;
+    }
+
+    return currentSetItem.call(this, key, value);
+  }
+
+  Object.defineProperty(protectedRouteSetItem, STORAGE_PATCH_MARKER, {
+    value: true,
+  });
+  Storage.prototype.setItem = protectedRouteSetItem;
+}
+
 function stopAuthWatcher() {
   if (pollTimer !== null) {
     window.clearInterval(pollTimer);
@@ -179,6 +211,7 @@ export function installProtectedRouteReturn() {
 
   originalPushState = window.history.pushState;
   originalReplaceState = window.history.replaceState;
+  installRegistrationOnboardingBypass();
 
   window.history.pushState = function pushState(state, title, url) {
     const result = originalPushState.call(this, state, title, url);

--- a/tests/e2e/seller-registration-redirect.spec.js
+++ b/tests/e2e/seller-registration-redirect.spec.js
@@ -5,12 +5,12 @@ const registeredUser = {
   name: 'Seller Redirect Test',
   email: 'seller-redirect@example.com',
   role: 'individual',
-  phone_verified: true,
+  phone_verified: false,
   email_verified_at: '2026-07-15T00:00:00Z',
 };
 
 test.describe('seller campaign registration return', () => {
-  test('opens the publication form after successful registration', async ({ page }) => {
+  test('opens the publication form without generic onboarding after registration', async ({ page }) => {
     await page.route('**/api/register', async (route) => {
       await route.fulfill({
         status: 201,
@@ -38,8 +38,11 @@ test.describe('seller campaign registration return', () => {
     await registrationForm.locator('button[type="submit"]').click();
 
     await expect(page).toHaveURL(/\/post$/);
-    await expect.poll(() => page.evaluate(() => (
-      sessionStorage.getItem('mercasto.protected_route_intent.v1')
-    ))).toBeNull();
+    await page.waitForTimeout(700);
+    await expect(page.getByRole('heading', { name: /¡Bienvenido/ })).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => ({
+      intent: sessionStorage.getItem('mercasto.protected_route_intent.v1'),
+      justRegistered: localStorage.getItem('just_registered'),
+    }))).toEqual({ intent: null, justRegistered: null });
   });
 });


### PR DESCRIPTION
## Summary
- Не устанавливаем общий флаг onboarding, когда регистрация началась из сохранённого защищённого маршрута `/post`.
- Ограничение применяется только к действующему seller/publication intent; все остальные новые пользователи продолжают видеть обычный onboarding.
- E2E-сценарий теперь использует нового пользователя без подтверждённого телефона и проверяет, что onboarding не перекрывает форму публикации.

## Risk
Низкий–средний. Изменение точечно оборачивает `Storage.prototype.setItem`, но пропускает без изменения все записи, кроме `localStorage.just_registered` при наличии валидного `/post` intent. При отсутствии intent поведение полностью прежнее.

## Smoke
- Прогнать frontend lint и build.
- Playwright-сценарий: `/vendedores` → CTA → регистрация пользователя с `phone_verified=false` → URL `/post`, onboarding отсутствует, временный intent и `just_registered` очищены.
- Проверить production smoke, Meta Pixel и TikTok Events API после деплоя.

## Rollback
Откатить этот PR. Сохранённый маршрут продолжит работать из PR #346, но общий onboarding снова будет появляться поверх формы у новых пользователей рекламного потока.