### PR TITLE
Keep catalog filler ads active without expiry

### DIFF
--- a/backend/app/Console/Commands/ExpireAds.php
+++ b/backend/app/Console/Commands/ExpireAds.php
@@ -17,6 +17,7 @@ class ExpireAds extends Command
     {
         $expiredAds = Ad::with('user:id,name,email')
             ->where('status', 'active')
+            ->where('is_catalog_filler', false)
             ->whereNotNull('expires_at')
             ->where('expires_at', '<=', now())
             ->get();

--- a/backend/app/Http/Middleware/EnforcePaidAdRenewal.php
+++ b/backend/app/Http/Middleware/EnforcePaidAdRenewal.php
@@ -44,6 +44,10 @@ class EnforcePaidAdRenewal
                     return response()->json(['message' => 'No tienes permisos para renovar este anuncio.'], 403);
                 }
 
+                if ((bool) ($ad->is_catalog_filler ?? false)) {
+                    return $next($request);
+                }
+
                 if ($action === 'activate' && $ad->status !== 'expired' && $this->hasTimeRemaining($ad)) {
                     return $next($request);
                 }
@@ -71,6 +75,7 @@ class EnforcePaidAdRenewal
             $expiredIds = DB::table('ads')
                 ->where('user_id', $user->id)
                 ->whereIn('id', $ids)
+                ->where('is_catalog_filler', false)
                 ->where(function ($query) {
                     $query->where('status', 'expired')
                         ->orWhereNull('expires_at')
@@ -95,6 +100,11 @@ class EnforcePaidAdRenewal
             $ad = DB::table('ads')->where('id', (int) $matches[1])->first();
             if ($ad
                 && (int) $ad->user_id === (int) $user->id
+                && (bool) ($ad->is_catalog_filler ?? false)) {
+                return $next($request);
+            }
+            if ($ad
+                && (int) $ad->user_id === (int) $user->id
                 && ($ad->status === 'expired' || ! $this->hasTimeRemaining($ad))) {
                 return $this->renewals->createCheckout($request, $ad);
             }
@@ -105,6 +115,10 @@ class EnforcePaidAdRenewal
 
     private function hasTimeRemaining(object $ad): bool
     {
+        if ((bool) ($ad->is_catalog_filler ?? false)) {
+            return true;
+        }
+
         return $ad->expires_at !== null && now()->lt($ad->expires_at);
     }
 
@@ -116,6 +130,7 @@ class EnforcePaidAdRenewal
 
         $expiredAds = DB::table('ads')
             ->where('status', 'active')
+            ->where('is_catalog_filler', false)
             ->whereNotNull('expires_at')
             ->where('expires_at', '<=', now())
             ->get(['id', 'user_id', 'title']);
@@ -133,6 +148,7 @@ class EnforcePaidAdRenewal
             DB::table('ads')
                 ->whereIn('id', $ids)
                 ->where('status', 'active')
+                ->where('is_catalog_filler', false)
                 ->update([
                     'status' => 'expired',
                     'updated_at' => $timestamp,

--- a/backend/app/Models/Ad.php
+++ b/backend/app/Models/Ad.php
@@ -29,6 +29,7 @@ class Ad extends Model
         'video_url',
         'video_processing_status',
         'status',
+        'is_catalog_filler',
         'moderation_submitted_at',
         'ai_moderation_status',
         'ai_moderation_reason',
@@ -55,6 +56,7 @@ class Ad extends Model
             'longitude' => 'decimal:7',
             'views' => 'integer',
             'republish_count' => 'integer',
+            'is_catalog_filler' => 'boolean',
             'expires_at' => 'datetime',
             'reminder_sent_at' => 'datetime',
             'republished_at' => 'datetime',
@@ -67,8 +69,23 @@ class Ad extends Model
         ];
     }
 
+    protected static function booted(): void
+    {
+        static::saving(function (Ad $ad): void {
+            if ($ad->is_catalog_filler) {
+                $ad->attributes['expires_at'] = null;
+                $ad->attributes['reminder_sent_at'] = null;
+            }
+        });
+    }
+
     public function setExpiresAtAttribute(mixed $value): void
     {
+        if ((bool) ($this->attributes['is_catalog_filler'] ?? false)) {
+            $this->attributes['expires_at'] = null;
+            return;
+        }
+
         if ($value === null || $value === '') {
             $this->attributes['expires_at'] = null;
             return;

--- a/backend/database/migrations/2026_07_20_160000_add_catalog_filler_lifetime_exemption.php
+++ b/backend/database/migrations/2026_07_20_160000_add_catalog_filler_lifetime_exemption.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('ads', 'is_catalog_filler')) {
+            Schema::table('ads', function (Blueprint $table) {
+                $table->boolean('is_catalog_filler')
+                    ->default(false)
+                    ->index()
+                    ->after('status');
+            });
+        }
+
+        $catalogOwnerEmails = [
+            'tienda_demo@mercasto.com',
+            'seller@example.com',
+            'johnnybroom@telegram.local',
+            'ivanagente452@gmail.com',
+            'reefmotorscom@gmail.com',
+        ];
+
+        $catalogOwnerIds = DB::table('users')
+            ->whereIn('email', $catalogOwnerEmails)
+            ->pluck('id');
+
+        if ($catalogOwnerIds->isEmpty()) {
+            return;
+        }
+
+        DB::table('ads')
+            ->whereIn('user_id', $catalogOwnerIds)
+            ->update([
+                'is_catalog_filler' => true,
+                'expires_at' => null,
+                'reminder_sent_at' => null,
+                'updated_at' => now(),
+            ]);
+
+        DB::table('ads')
+            ->whereIn('user_id', $catalogOwnerIds)
+            ->whereIn('status', ['active', 'expired', 'paused', 'inactive'])
+            ->update([
+                'status' => 'active',
+                'expires_at' => null,
+                'reminder_sent_at' => null,
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('ads', 'is_catalog_filler')) {
+            return;
+        }
+
+        DB::table('ads')
+            ->where('is_catalog_filler', true)
+            ->where('status', 'active')
+            ->update([
+                'expires_at' => now()->addDays((int) config('marketplace.ad_lifetime_days', 7)),
+                'updated_at' => now(),
+            ]);
+
+        Schema::table('ads', function (Blueprint $table) {
+            $table->dropIndex(['is_catalog_filler']);
+            $table->dropColumn('is_catalog_filler');
+        });
+    }
+};

--- a/backend/tests/Feature/PaidAdRenewalTest.php
+++ b/backend/tests/Feature/PaidAdRenewalTest.php
@@ -27,6 +27,34 @@ class PaidAdRenewalTest extends TestCase
         $this->assertTrue($ad->expires_at->gte(now()->addDays(7)->subMinute()));
     }
 
+    public function test_catalog_filler_ad_stays_active_without_expiry_or_payment(): void
+    {
+        $seller = User::factory()->create();
+        $ad = $this->createAd($seller, [
+            'status' => 'active',
+            'is_catalog_filler' => true,
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $this->assertTrue($ad->is_catalog_filler);
+        $this->assertNull($ad->expires_at);
+
+        $this->artisan('ads:expire')->assertSuccessful();
+
+        $ad->refresh();
+        $this->assertSame('active', $ad->status);
+        $this->assertNull($ad->expires_at);
+
+        Sanctum::actingAs($seller);
+        $response = $this->putJson("/api/ads/{$ad->id}/renew");
+
+        $this->assertNotSame(402, $response->status());
+        $this->assertDatabaseMissing('payments', [
+            'ad_id' => $ad->id,
+            'product_code' => 'ad_renewal_7_days',
+        ]);
+    }
+
     public function test_expired_ad_requires_fixed_49_mxn_clip_checkout(): void
     {
         config([


### PR DESCRIPTION
## Summary

- Adds an explicit `is_catalog_filler` flag to ads.
- Marks the existing catalog batches owned by Mercasto Pro, Seller Demo, Johnny, Iván Medina, and Reef Motors as catalog fillers.
- Reactivates only filler ads currently in `active`, `expired`, `paused`, or `inactive` states; rejected, archived, and moderation records are not revived.
- Catalog fillers keep `expires_at = NULL`, are skipped by scheduled and request-time expiry, and never enter the 49 MXN renewal flow.
- Normal customer ads still expire after 7 days and require the existing 49 MXN Clip renewal.

## Risk

- The migration intentionally updates existing production catalog ads and restores their active status.
- QA data owned by `seller_e2e@mercasto.com` is deliberately excluded.
- No payment configuration or customer-owned ad is changed.

## Smoke

1. Run backend tests including `PaidAdRenewalTest`.
2. Apply the migration and confirm catalog fillers are active with null `expires_at`.
3. Confirm normal ads still receive a seven-day expiry.
4. Run `ads:expire` and verify filler ads remain active.
5. Confirm filler renew/activate actions do not create Clip payment rows.

## Rollback

- Roll back the migration to remove the flag and restore a seven-day expiry to active filler ads.
- Revert this PR to restore the previous expiry behavior.

## Configuration

- No new environment variables are required.