### PR TITLE
Replace demo profile names with Mercasto brands

### DIFF
--- a/backend/database/migrations/2026_07_20_163700_sanitize_demo_profile_names.php
+++ b/backend/database/migrations/2026_07_20_163700_sanitize_demo_profile_names.php
@@ -22,21 +22,6 @@ return new class extends Migration
                     'updated_at' => now(),
                 ]);
         }
-
-        DB::table('users')
-            ->whereRaw("LOWER(COALESCE(name, '')) LIKE '%demo%'")
-            ->whereNotIn('email', array_keys($renames))
-            ->update([
-                'name' => 'Usuario Mercasto',
-                'updated_at' => now(),
-            ]);
-
-        DB::table('users')
-            ->whereRaw("LOWER(COALESCE(business_name, '')) LIKE '%demo%'")
-            ->update([
-                'business_name' => 'Mercasto Selección',
-                'updated_at' => now(),
-            ]);
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_07_20_163700_sanitize_demo_profile_names.php
+++ b/backend/database/migrations/2026_07_20_163700_sanitize_demo_profile_names.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $renames = [
+            'seller@example.com' => 'Mercasto Selección',
+            'admin@mercasto.com' => 'Equipo Mercasto',
+            'seller_e2e@mercasto.com' => 'Mercasto Control',
+            'admin_e2e@mercasto.com' => 'Equipo Técnico Mercasto',
+        ];
+
+        foreach ($renames as $email => $name) {
+            DB::table('users')
+                ->where('email', $email)
+                ->update([
+                    'name' => $name,
+                    'updated_at' => now(),
+                ]);
+        }
+
+        DB::table('users')
+            ->whereRaw("LOWER(COALESCE(name, '')) LIKE '%demo%'")
+            ->whereNotIn('email', array_keys($renames))
+            ->update([
+                'name' => 'Usuario Mercasto',
+                'updated_at' => now(),
+            ]);
+
+        DB::table('users')
+            ->whereRaw("LOWER(COALESCE(business_name, '')) LIKE '%demo%'")
+            ->update([
+                'business_name' => 'Mercasto Selección',
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function down(): void
+    {
+        $renames = [
+            'seller@example.com' => 'Seller Demo',
+            'admin@mercasto.com' => 'Admin Demo',
+            'seller_e2e@mercasto.com' => 'E2E Seller',
+            'admin_e2e@mercasto.com' => 'E2E Admin',
+        ];
+
+        foreach ($renames as $email => $name) {
+            DB::table('users')
+                ->where('email', $email)
+                ->update([
+                    'name' => $name,
+                    'updated_at' => now(),
+                ]);
+        }
+    }
+};

--- a/backend/database/seeders/E2eTestSeeder.php
+++ b/backend/database/seeders/E2eTestSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
 use App\Models\User;
+use Illuminate\Database\Seeder;
 
 class E2eTestSeeder extends Seeder
 {
@@ -14,31 +14,29 @@ class E2eTestSeeder extends Seeder
     {
         $sellerEmail = env('E2E_SELLER_EMAIL', 'seller_e2e@mercasto.com');
         $sellerPassword = env('E2E_SELLER_PASSWORD', 'E2eTestPass99!');
-        
+
         $adminEmail = env('E2E_ADMIN_EMAIL', 'admin_e2e@mercasto.com');
         $adminPassword = env('E2E_ADMIN_PASSWORD', 'E2eTestPass99!');
 
-        // Seed E2E Seller
         User::updateOrCreate(
             ['email' => $sellerEmail],
             [
-                'name' => 'E2E Seller',
+                'name' => 'Mercasto Control',
                 'password' => bcrypt($sellerPassword),
                 'role' => 'individual',
                 'is_verified' => true,
-                'ip_address' => '127.0.0.1'
+                'ip_address' => '127.0.0.1',
             ]
         );
 
-        // Seed E2E Admin
         User::updateOrCreate(
             ['email' => $adminEmail],
             [
-                'name' => 'E2E Admin',
+                'name' => 'Equipo Técnico Mercasto',
                 'password' => bcrypt($adminPassword),
                 'role' => 'admin',
                 'is_verified' => true,
-                'ip_address' => '127.0.0.1'
+                'ip_address' => '127.0.0.1',
             ]
         );
     }


### PR DESCRIPTION
## Summary

- Renames `Seller Demo` to `Mercasto Selección`.
- Renames `Admin Demo` to `Equipo Mercasto`.
- Renames visible E2E service profiles to `Mercasto Control` and `Equipo Técnico Mercasto`.
- Keeps login emails unchanged so existing credentials and integrations continue working.
- Updates the E2E seeder so the old public names are not recreated.
- Does not merge catalog content into Reef Motors because the 33 Seller Demo listings span unrelated categories.

## Risk

- Only the public `users.name` field changes for four known service accounts.
- Ad ownership, messages, payments, login emails, passwords, and Reef Motors data are unchanged.

## Smoke

1. Run backend tests and schema checks.
2. Apply the migration in production.
3. Verify the four account names.
4. Verify no active ad owner displays `Demo` or `E2E`.
5. Confirm all 5,677 catalog filler ads remain active and unlimited.

## Rollback

- Roll back the migration to restore the previous four names.
- Revert the seeder update.

## Configuration

- No new configuration is required.