### PR TITLE
Prevent mismatched frontend assets during production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,34 @@
-name: Deploy Mercasto Frontend Hotfix
+name: Deploy Mercasto Frontend
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.*'
+      - 'Dockerfile'
+      - 'default.conf'
+      - 'security_headers.conf'
+      - 'scripts/verify-vite-dist.mjs'
+      - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
 concurrency:
   group: production-frontend-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Find project directory
@@ -57,21 +75,128 @@ jobs:
           git reset --hard origin/main
           git clean -fd
 
-      - name: Build frontend
+      - name: Build frontend image
         run: |
           set -euo pipefail
           cd "$PROJECT_DIR"
           DOCKER_BUILDKIT=1 docker compose build --no-cache mercasto-frontend
 
-      - name: Restart frontend
+      - name: Verify built Vite bundle
         run: |
           set -euo pipefail
           cd "$PROJECT_DIR"
-          docker compose up -d --no-deps mercasto-frontend
-          docker compose ps
 
-      - name: Smoke check
+          image_id=$(docker compose images -q mercasto-frontend)
+          if [ -z "$image_id" ]; then
+            echo "Built frontend image was not found."
+            exit 1
+          fi
+
+          dist_dir="${RUNNER_TEMP:-/tmp}/mercasto-dist-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf "$dist_dir"
+          mkdir -p "$dist_dir"
+
+          container_id=$(docker create "$image_id")
+          cleanup_container() {
+            docker rm -f "$container_id" >/dev/null 2>&1 || true
+          }
+          trap cleanup_container EXIT
+
+          docker cp "$container_id:/usr/share/nginx/html/." "$dist_dir/"
+          cleanup_container
+          trap - EXIT
+
+          docker run --rm \
+            -v "$PROJECT_DIR/scripts/verify-vite-dist.mjs:/verify-vite-dist.mjs:ro" \
+            -v "$dist_dir:/dist:ro" \
+            node:22-alpine \
+            node /verify-vite-dist.mjs /dist
+
+          echo "DIST_DIR=$dist_dir" >> "$GITHUB_ENV"
+
+      - name: Restart frontend atomically
         run: |
           set -euo pipefail
-          curl -I --max-time 30 https://mercasto.com/
-          curl -sS --max-time 30 https://mercasto.com/api/categories | head -c 300
+          cd "$PROJECT_DIR"
+
+          docker compose up -d --no-deps --force-recreate mercasto-frontend
+
+          for attempt in $(seq 1 30); do
+            status=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' mercasto_frontend_container 2>/dev/null || true)
+            echo "Frontend status: ${status:-unknown}"
+            if [ "$status" = "healthy" ] || [ "$status" = "running" ]; then
+              break
+            fi
+            if [ "$status" = "unhealthy" ] || [ "$status" = "exited" ] || [ "$status" = "dead" ]; then
+              docker logs --tail 200 mercasto_frontend_container || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+          final_status=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' mercasto_frontend_container)
+          if [ "$final_status" != "healthy" ] && [ "$final_status" != "running" ]; then
+            docker logs --tail 200 mercasto_frontend_container || true
+            echo "Frontend did not become ready."
+            exit 1
+          fi
+
+          docker compose ps
+
+      - name: Verify production HTML and every Vite asset
+        run: |
+          set -euo pipefail
+
+          live_dir="${RUNNER_TEMP:-/tmp}/mercasto-live-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf "$live_dir"
+          mkdir -p "$live_dir"
+
+          cleanup_live() {
+            rm -rf "$live_dir" "$DIST_DIR"
+          }
+          trap cleanup_live EXIT
+
+          curl_args=(
+            --fail
+            --silent
+            --show-error
+            --location
+            --retry 5
+            --retry-delay 2
+            --retry-all-errors
+            --max-time 30
+            -H 'Cache-Control: no-cache'
+            -H 'Accept-Encoding: identity'
+          )
+
+          curl "${curl_args[@]}" "https://mercasto.com/?deploy=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" -o "$live_dir/index.html"
+          if ! cmp -s "$DIST_DIR/index.html" "$live_dir/index.html"; then
+            echo "Production index.html does not match the image that was just deployed."
+            diff -u "$DIST_DIR/index.html" "$live_dir/index.html" | head -200 || true
+            exit 1
+          fi
+
+          checked=0
+          while IFS= read -r relative_path; do
+            target="$live_dir/$relative_path"
+            mkdir -p "$(dirname "$target")"
+            curl "${curl_args[@]}" "https://mercasto.com/${relative_path}?deploy=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" -o "$target"
+
+            if ! cmp -s "$DIST_DIR/$relative_path" "$target"; then
+              echo "Production asset differs from the deployed image: $relative_path"
+              exit 1
+            fi
+            checked=$((checked + 1))
+          done < <(cd "$DIST_DIR" && find assets -type f -print | sort)
+
+          if [ "$checked" -eq 0 ]; then
+            echo "No production assets were checked."
+            exit 1
+          fi
+
+          echo "Production bundle verified: index.html and $checked assets match the deployed image."
+
+      - name: API smoke check
+        run: |
+          set -euo pipefail
+          curl -fsS --retry 5 --retry-all-errors --max-time 30 https://mercasto.com/api/categories | head -c 300

--- a/scripts/verify-vite-dist.mjs
+++ b/scripts/verify-vite-dist.mjs
@@ -7,8 +7,8 @@ import process from 'node:process';
 const distRoot = path.resolve(process.argv[2] ?? 'dist');
 const textExtensions = new Set(['.html', '.js', '.css', '.json', '.webmanifest', '.svg']);
 const assetExtensions = 'js|css|map|json|wasm|woff2?|ttf|otf|eot|svg|png|jpe?g|webp|avif|gif|ico';
-const absoluteAssetPattern = new RegExp(`(?:/)?assets/[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'\\`)]+)?`, 'g');
-const relativeAssetPattern = new RegExp(`\\./[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'\\`)]+)?`, 'g');
+const absoluteAssetPattern = new RegExp(`(?:/)?assets/[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'()\\x60]+)?`, 'g');
+const relativeAssetPattern = new RegExp(`\\./[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'()\\x60]+)?`, 'g');
 
 async function walk(directory) {
   const entries = await readdir(directory, { withFileTypes: true });

--- a/scripts/verify-vite-dist.mjs
+++ b/scripts/verify-vite-dist.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const distRoot = path.resolve(process.argv[2] ?? 'dist');
+const textExtensions = new Set(['.html', '.js', '.css', '.json', '.webmanifest', '.svg']);
+const assetExtensions = 'js|css|map|json|wasm|woff2?|ttf|otf|eot|svg|png|jpe?g|webp|avif|gif|ico';
+const absoluteAssetPattern = new RegExp(`(?:/)?assets/[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'\\`)]+)?`, 'g');
+const relativeAssetPattern = new RegExp(`\\./[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'\\`)]+)?`, 'g');
+
+async function walk(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(fullPath));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function stripQueryAndHash(reference) {
+  return reference.split(/[?#]/, 1)[0];
+}
+
+function resolveReference(sourceFile, reference) {
+  const cleanReference = stripQueryAndHash(reference);
+
+  if (cleanReference.startsWith('/assets/')) {
+    return path.join(distRoot, cleanReference.slice(1));
+  }
+
+  if (cleanReference.startsWith('assets/')) {
+    return path.join(distRoot, cleanReference);
+  }
+
+  if (cleanReference.startsWith('./')) {
+    return path.resolve(path.dirname(sourceFile), cleanReference);
+  }
+
+  return null;
+}
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!await exists(path.join(distRoot, 'index.html'))) {
+  console.error(`Missing Vite entrypoint: ${path.join(distRoot, 'index.html')}`);
+  process.exit(1);
+}
+
+const allFiles = await walk(distRoot);
+const assetFiles = allFiles.filter(file => file.startsWith(path.join(distRoot, 'assets') + path.sep));
+const javascriptFiles = assetFiles.filter(file => file.endsWith('.js'));
+
+if (javascriptFiles.length === 0) {
+  console.error('The Vite bundle contains no JavaScript assets.');
+  process.exit(1);
+}
+
+const missing = new Map();
+let referencesChecked = 0;
+
+for (const sourceFile of allFiles) {
+  if (!textExtensions.has(path.extname(sourceFile).toLowerCase())) {
+    continue;
+  }
+
+  const content = await readFile(sourceFile, 'utf8');
+  const references = new Set([
+    ...(content.match(absoluteAssetPattern) ?? []),
+    ...(content.match(relativeAssetPattern) ?? []),
+  ]);
+
+  for (const reference of references) {
+    const target = resolveReference(sourceFile, reference);
+    if (!target) {
+      continue;
+    }
+
+    const normalizedTarget = path.resolve(target);
+    if (normalizedTarget !== distRoot && !normalizedTarget.startsWith(distRoot + path.sep)) {
+      continue;
+    }
+
+    referencesChecked += 1;
+    if (!await exists(normalizedTarget)) {
+      const relativeSource = path.relative(distRoot, sourceFile);
+      const list = missing.get(relativeSource) ?? [];
+      list.push(reference);
+      missing.set(relativeSource, list);
+    }
+  }
+}
+
+if (missing.size > 0) {
+  console.error('The Vite bundle contains references to missing files:');
+  for (const [source, references] of missing) {
+    for (const reference of references) {
+      console.error(`- ${source} -> ${reference}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log(`Vite bundle verified: ${assetFiles.length} asset files, ${referencesChecked} internal references checked.`);


### PR DESCRIPTION
## Summary

- Makes frontend production deployment run automatically for frontend-related changes merged into `main`.
- Forces recreation of the frontend container so the newly built image is always activated.
- Extracts the built Vite bundle and validates that every internal asset reference exists before rollout.
- After rollout, compares production `index.html` and every generated Vite asset byte-for-byte with the deployed image.
- Fails deployment instead of leaving production with new HTML and missing or stale chunks.

## Risk

- The frontend container is recreated during deployment, causing a brief connection handoff.
- Production verification downloads all generated frontend assets once per deployment.
- Backend-only changes do not trigger this frontend workflow.

## Smoke

1. Build the frontend image without cache.
2. Verify the Vite module graph inside the image.
3. Force-recreate `mercasto-frontend` and wait for readiness.
4. Compare live `index.html` with the image.
5. Compare every live `/assets/*` file with the image.
6. Confirm `/api/categories` remains reachable.

## Rollback

- Revert this pull request to restore the manual-only frontend deployment workflow.
- Re-run the previous frontend image if production verification detects an infrastructure-specific mismatch.