### PR TITLE
Narrow Vite integrity checks to actual module references

### DIFF
--- a/scripts/verify-vite-dist.mjs
+++ b/scripts/verify-vite-dist.mjs
@@ -7,8 +7,9 @@ import process from 'node:process';
 const distRoot = path.resolve(process.argv[2] ?? 'dist');
 const textExtensions = new Set(['.html', '.js', '.css', '.json', '.webmanifest', '.svg']);
 const assetExtensions = 'js|css|map|json|wasm|woff2?|ttf|otf|eot|svg|png|jpe?g|webp|avif|gif|ico';
-const absoluteAssetPattern = new RegExp(`(?:/)?assets/[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'()\\x60]+)?`, 'g');
-const relativeAssetPattern = new RegExp(`\\./[A-Za-z0-9_@./-]+\\.(?:${assetExtensions})(?:[?#][^\\s"'()\\x60]+)?`, 'g');
+const referenceSuffix = '(?:[?#][^\\s"\'()\\x60]+)?';
+const absoluteAsset = `((?:/)?assets/[A-Za-z0-9_@./-]+\\.(?:${assetExtensions}))${referenceSuffix}`;
+const relativeAsset = `(\\./[A-Za-z0-9_@./-]+\\.(?:${assetExtensions}))${referenceSuffix}`;
 
 async function walk(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -24,6 +25,44 @@ async function walk(directory) {
   }
 
   return files;
+}
+
+function collectMatches(content, pattern, target) {
+  for (const match of content.matchAll(pattern)) {
+    if (match[1]) {
+      target.add(match[1]);
+    }
+  }
+}
+
+function collectReferences(content, extension) {
+  const references = new Set();
+
+  collectMatches(content, new RegExp(`["'\\x60]${absoluteAsset}["'\\x60]`, 'g'), references);
+
+  if (extension === '.html' || extension === '.svg') {
+    collectMatches(content, new RegExp(`(?:src|href)\\s*=\\s*["']${absoluteAsset}["']`, 'gi'), references);
+  }
+
+  if (extension === '.css' || extension === '.html' || extension === '.svg') {
+    collectMatches(content, new RegExp(`url\\(\\s*["']?${absoluteAsset}["']?\\s*\\)`, 'gi'), references);
+    collectMatches(content, new RegExp(`url\\(\\s*["']?${relativeAsset}["']?\\s*\\)`, 'gi'), references);
+  }
+
+  if (extension === '.js') {
+    collectMatches(
+      content,
+      new RegExp(`(?:\\bfrom\\s*|\\bimport\\s*\\(\\s*|\\bimport\\s*)["'\\x60]${relativeAsset}["'\\x60]`, 'g'),
+      references,
+    );
+    collectMatches(
+      content,
+      new RegExp(`\\bnew\\s+URL\\(\\s*["'\\x60]${relativeAsset}["'\\x60]\\s*,\\s*import\\.meta\\.url`, 'g'),
+      references,
+    );
+  }
+
+  return references;
 }
 
 function stripQueryAndHash(reference) {
@@ -63,7 +102,8 @@ if (!await exists(path.join(distRoot, 'index.html'))) {
 }
 
 const allFiles = await walk(distRoot);
-const assetFiles = allFiles.filter(file => file.startsWith(path.join(distRoot, 'assets') + path.sep));
+const assetRoot = path.join(distRoot, 'assets') + path.sep;
+const assetFiles = allFiles.filter(file => file.startsWith(assetRoot));
 const javascriptFiles = assetFiles.filter(file => file.endsWith('.js'));
 
 if (javascriptFiles.length === 0) {
@@ -75,15 +115,13 @@ const missing = new Map();
 let referencesChecked = 0;
 
 for (const sourceFile of allFiles) {
-  if (!textExtensions.has(path.extname(sourceFile).toLowerCase())) {
+  const extension = path.extname(sourceFile).toLowerCase();
+  if (!textExtensions.has(extension)) {
     continue;
   }
 
   const content = await readFile(sourceFile, 'utf8');
-  const references = new Set([
-    ...(content.match(absoluteAssetPattern) ?? []),
-    ...(content.match(relativeAssetPattern) ?? []),
-  ]);
+  const references = collectReferences(content, extension);
 
   for (const reference of references) {
     const target = resolveReference(sourceFile, reference);
@@ -113,6 +151,11 @@ if (missing.size > 0) {
       console.error(`- ${source} -> ${reference}`);
     }
   }
+  process.exit(1);
+}
+
+if (referencesChecked === 0) {
+  console.error('The Vite bundle verifier found no internal asset references.');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- Stops treating every arbitrary `./*.js` string inside bundled libraries as a Vite chunk.
- Validates only real module imports (`from`, `import()`, bare `import`), `new URL(..., import.meta.url)`, HTML `src`/`href`, and CSS `url()` references.
- Retains detection of missing generated chunks such as `SearchSuggestions-*.js`.
- Fails if the bundle contains no JavaScript or no internal references at all.

## Risk

- The verifier is intentionally narrower and no longer checks unrelated runtime strings that happen to resemble relative filenames.
- Real Vite imports and generated asset references remain blocking.

## Smoke

1. Verify a synthetic bundle with static imports, dynamic imports, CSS fonts, and `new URL` assets.
2. Confirm an unrelated string like `./not-a-real-runtime.js` is ignored.
3. Delete a dynamically imported chunk and confirm verification fails.
4. Run the primary production deployment and require the `production/frontend-assets` status.

## Rollback

- Revert this pull request to restore the broad string-based scanner.