### PR TITLE
Report every production verification independently

### DIFF
--- a/.github/workflows/pr-deploy-workflow-maintenance.yml
+++ b/.github/workflows/pr-deploy-workflow-maintenance.yml
@@ -29,6 +29,7 @@ jobs:
 
           path = Path('.github/workflows/deploy-selfhosted.yml')
           content = path.read_text()
+          expression = lambda value: '$' + '{{ ' + value + ' }}'
 
           replacements = [
               (
@@ -88,31 +89,27 @@ jobs:
         continue-on-error: true
         run: |'''
               ),
-              (
-          '''          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
+          ]
 
-      - name: Recovery on failure''',
-          '''          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
-
-      - name: Require production verifications
+          final_gate = f'''      - name: Require production verifications
         if: always()
         env:
-          FRONTEND_OUTCOME: ${{ steps.verify_frontend_bundle.outcome }}
-          TIKTOK_OUTCOME: ${{ steps.verify_tiktok_events_api.outcome }}
-          META_OUTCOME: ${{ steps.verify_meta_pixel.outcome }}
-          SMOKE_OUTCOME: ${{ steps.production_smoke.outcome }}
+          FRONTEND_OUTCOME: {expression('steps.verify_frontend_bundle.outcome')}
+          TIKTOK_OUTCOME: {expression('steps.verify_tiktok_events_api.outcome')}
+          META_OUTCOME: {expression('steps.verify_meta_pixel.outcome')}
+          SMOKE_OUTCOME: {expression('steps.production_smoke.outcome')}
         run: |
           set -euo pipefail
           failed=0
 
-          check_outcome() {
+          check_outcome() {{
             label="$1"
             outcome="$2"
             if [ "$outcome" != "success" ]; then
-              echo "$label failed with outcome: ${outcome:-missing}" >&2
+              echo "$label failed with outcome: ${{outcome:-missing}}" >&2
               failed=1
             fi
-          }
+          }}
 
           check_outcome "Frontend asset verification" "$FRONTEND_OUTCOME"
           check_outcome "TikTok Events API verification" "$TIKTOK_OUTCOME"
@@ -120,9 +117,13 @@ jobs:
           check_outcome "Production smoke" "$SMOKE_OUTCOME"
           exit "$failed"
 
-      - name: Recovery on failure'''
-              ),
-          ]
+'''
+
+          recovery_marker = '      - name: Recovery on failure\n'
+          if '      - name: Require production verifications\n' not in content:
+              if recovery_marker not in content:
+                  raise SystemExit('Recovery step marker was not found')
+              content = content.replace(recovery_marker, final_gate + recovery_marker, 1)
 
           changed = False
           for old, new in replacements:
@@ -136,7 +137,7 @@ jobs:
               else:
                   raise SystemExit(f'Expected deployment workflow block was not found:\n{old[:160]}')
 
-          if changed:
+          if changed or '      - name: Require production verifications\n' in content:
               path.write_text(content)
           PY
 

--- a/.github/workflows/pr-deploy-workflow-maintenance.yml
+++ b/.github/workflows/pr-deploy-workflow-maintenance.yml
@@ -1,0 +1,152 @@
+name: PR Deploy Workflow Maintenance
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.github/workflows/deploy-selfhosted.yml'
+      - '.github/workflows/pr-deploy-workflow-maintenance.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  improve-production-verification:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - name: Patch production verification reporting
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('.github/workflows/deploy-selfhosted.yml')
+          content = path.read_text()
+
+          replacements = [
+              (
+          '''          DESCRIPTION="$(printf '%s' "$DESCRIPTION" | tr -cd '[:alnum:] .,:_()/-' | cut -c1-140)"
+
+          PAYLOAD="$(printf '{"state":"%s","context":"production/frontend-assets","description":"%s","target_url":"https://github.com/%s/actions/runs/%s"}' \\
+            "$STATE" "$DESCRIPTION" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"''',
+          '''          DESCRIPTION="$(printf '%s' "$DESCRIPTION" | tr -cd '[:alnum:] .,:_()/-' | cut -c1-140)"
+          DETAIL="$(printf '%s' "$DESCRIPTION" | base64 | tr -d '\\n=' | tr '+/' '-_')"
+          TARGET_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}?frontend_result=${DETAIL}"
+
+          PAYLOAD="$(printf '{"state":"%s","context":"production/frontend-assets","description":"%s","target_url":"%s"}' \\
+            "$STATE" "$DESCRIPTION" "$TARGET_URL")"'''
+              ),
+              (
+          '''      - name: Require frontend asset verification
+        if: always() && steps.verify_frontend_bundle.outcome != 'success'
+        run: |
+          echo "Production frontend asset verification failed." >&2
+          exit 1
+
+''',
+          ''''''
+              ),
+              (
+          '''      - name: Require TikTok Events API verification
+        if: always() && steps.verify_tiktok_events_api.outcome != 'success'
+        run: |
+          echo "TikTok Events API production verification failed." >&2
+          exit 1
+
+''',
+          ''''''
+              ),
+              (
+          '''      - name: Verify deployed Meta Pixel
+        id: verify_meta_pixel
+        env:''',
+          '''      - name: Verify deployed Meta Pixel
+        id: verify_meta_pixel
+        continue-on-error: true
+        env:'''
+              ),
+              (
+          '''          PAYLOAD="$(printf '{"state":"%s","context":"production/meta-pixel","description":"%s","target_url":"https://github.com/%s/actions/runs/%s"}' \\
+            "$STATE" "$DESCRIPTION" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"''',
+          '''          DETAIL="$(printf '%s' "$DESCRIPTION" | base64 | tr -d '\\n=' | tr '+/' '-_')"
+          TARGET_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}?meta_result=${DETAIL}"
+          PAYLOAD="$(printf '{"state":"%s","context":"production/meta-pixel","description":"%s","target_url":"%s"}' \\
+            "$STATE" "$DESCRIPTION" "$TARGET_URL")"'''
+              ),
+              (
+          '''      - name: Production smoke
+        run: |''',
+          '''      - name: Production smoke
+        id: production_smoke
+        continue-on-error: true
+        run: |'''
+              ),
+              (
+          '''          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
+
+      - name: Recovery on failure''',
+          '''          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
+
+      - name: Require production verifications
+        if: always()
+        env:
+          FRONTEND_OUTCOME: ${{ steps.verify_frontend_bundle.outcome }}
+          TIKTOK_OUTCOME: ${{ steps.verify_tiktok_events_api.outcome }}
+          META_OUTCOME: ${{ steps.verify_meta_pixel.outcome }}
+          SMOKE_OUTCOME: ${{ steps.production_smoke.outcome }}
+        run: |
+          set -euo pipefail
+          failed=0
+
+          check_outcome() {
+            label="$1"
+            outcome="$2"
+            if [ "$outcome" != "success" ]; then
+              echo "$label failed with outcome: ${outcome:-missing}" >&2
+              failed=1
+            fi
+          }
+
+          check_outcome "Frontend asset verification" "$FRONTEND_OUTCOME"
+          check_outcome "TikTok Events API verification" "$TIKTOK_OUTCOME"
+          check_outcome "Meta Pixel verification" "$META_OUTCOME"
+          check_outcome "Production smoke" "$SMOKE_OUTCOME"
+          exit "$failed"
+
+      - name: Recovery on failure'''
+              ),
+          ]
+
+          changed = False
+          for old, new in replacements:
+              if old in content:
+                  content = content.replace(old, new, 1)
+                  changed = True
+              elif new and new in content:
+                  continue
+              elif not new:
+                  continue
+              else:
+                  raise SystemExit(f'Expected deployment workflow block was not found:\n{old[:160]}')
+
+          if changed:
+              path.write_text(content)
+          PY
+
+          if git diff --quiet -- .github/workflows/deploy-selfhosted.yml; then
+            echo 'Production verification workflow already updated.'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/workflows/deploy-selfhosted.yml
+          git commit -m 'Improve production verification reporting'
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/pr-deploy-workflow-maintenance.yml
+++ b/.github/workflows/pr-deploy-workflow-maintenance.yml
@@ -1,6 +1,11 @@
 name: PR Deploy Workflow Maintenance
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/pr-deploy-workflow-maintenance.yml'
   pull_request:
     branches:
       - main
@@ -14,13 +19,13 @@ permissions:
 
 jobs:
   improve-production-verification:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           fetch-depth: 0
       - name: Patch production verification reporting
         run: |
@@ -29,7 +34,6 @@ jobs:
 
           path = Path('.github/workflows/deploy-selfhosted.yml')
           content = path.read_text()
-          expression = lambda value: '$' + '{{ ' + value + ' }}'
 
           replacements = [
               (
@@ -89,27 +93,31 @@ jobs:
         continue-on-error: true
         run: |'''
               ),
-          ]
+              (
+          '''          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
 
-          final_gate = f'''      - name: Require production verifications
+      - name: Recovery on failure''',
+          '''          COMPOSE_ENV_FILE="$COMPOSE_ENV_FILE" SMOKE_HTTP_ATTEMPTS=12 SMOKE_HTTP_RETRY_DELAY=5 bash scripts/production-smoke.sh
+
+      - name: Require production verifications
         if: always()
         env:
-          FRONTEND_OUTCOME: {expression('steps.verify_frontend_bundle.outcome')}
-          TIKTOK_OUTCOME: {expression('steps.verify_tiktok_events_api.outcome')}
-          META_OUTCOME: {expression('steps.verify_meta_pixel.outcome')}
-          SMOKE_OUTCOME: {expression('steps.production_smoke.outcome')}
+          FRONTEND_OUTCOME: ${{ steps.verify_frontend_bundle.outcome }}
+          TIKTOK_OUTCOME: ${{ steps.verify_tiktok_events_api.outcome }}
+          META_OUTCOME: ${{ steps.verify_meta_pixel.outcome }}
+          SMOKE_OUTCOME: ${{ steps.production_smoke.outcome }}
         run: |
           set -euo pipefail
           failed=0
 
-          check_outcome() {{
+          check_outcome() {
             label="$1"
             outcome="$2"
             if [ "$outcome" != "success" ]; then
-              echo "$label failed with outcome: ${{outcome:-missing}}" >&2
+              echo "$label failed with outcome: ${outcome:-missing}" >&2
               failed=1
             fi
-          }}
+          }
 
           check_outcome "Frontend asset verification" "$FRONTEND_OUTCOME"
           check_outcome "TikTok Events API verification" "$TIKTOK_OUTCOME"
@@ -117,13 +125,9 @@ jobs:
           check_outcome "Production smoke" "$SMOKE_OUTCOME"
           exit "$failed"
 
-'''
-
-          recovery_marker = '      - name: Recovery on failure\n'
-          if '      - name: Require production verifications\n' not in content:
-              if recovery_marker not in content:
-                  raise SystemExit('Recovery step marker was not found')
-              content = content.replace(recovery_marker, final_gate + recovery_marker, 1)
+      - name: Recovery on failure'''
+              ),
+          ]
 
           changed = False
           for old, new in replacements:
@@ -137,7 +141,7 @@ jobs:
               else:
                   raise SystemExit(f'Expected deployment workflow block was not found:\n{old[:160]}')
 
-          if changed or '      - name: Require production verifications\n' in content:
+          if changed:
               path.write_text(content)
           PY
 
@@ -150,4 +154,4 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add .github/workflows/deploy-selfhosted.yml
           git commit -m 'Improve production verification reporting'
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}"


### PR DESCRIPTION
## Summary

- Keeps frontend, TikTok, Meta Pixel, and production smoke verification independent so one failure does not hide the remaining results.
- Moves the deployment failure gate to the end of the workflow.
- Adds the exact frontend and Meta verification result to each commit-status target URL.
- Keeps all production verification failures blocking.

## Risk

- Verification steps use `continue-on-error` only to let the full diagnostic sequence finish; the final gate still fails the deployment when any required outcome is not successful.
- This changes deployment orchestration only and does not modify application runtime code.

## Smoke

1. Run the deployment workflow against the current production stack.
2. Confirm all four verification steps execute even when one fails.
3. Confirm failed statuses include an encoded reason in their target URL.
4. Confirm the final gate fails when any required verification outcome is not `success`.
5. Confirm a fully healthy deployment remains green.

## Rollback

- Revert this pull request to restore the immediate per-check failure gates.