### PR TITLE
Add seller lifecycle reminders and buyer conversion nudges

### DIFF
--- a/backend/app/Console/Commands/ExpireAds.php
+++ b/backend/app/Console/Commands/ExpireAds.php
@@ -6,15 +6,20 @@ use App\Models\Ad;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class ExpireAds extends Command
 {
     protected $signature = 'ads:expire';
-    protected $description = 'Mark active ads as expired when their expires_at date has passed and notify owners.';
+    protected $description = 'Warn sellers before expiry, expire due ads, and send lifecycle conversion notifications.';
 
     public function handle(): int
     {
+        $amount = (float) config('marketplace.ad_renewal_price_mxn', 49);
+        $renewalDays = (int) config('marketplace.ad_renewal_days', 7);
+        $warningCount = $this->sendExpiryWarnings($amount, $renewalDays);
+
         $expiredAds = Ad::with('user:id,name,email')
             ->where('status', 'active')
             ->where('is_catalog_filler', false)
@@ -22,58 +27,102 @@ class ExpireAds extends Command
             ->where('expires_at', '<=', now())
             ->get();
 
-        if ($expiredAds->isEmpty()) {
-            $this->info('No ads to expire.');
-            return self::SUCCESS;
-        }
-
-        $amount = (float) config('marketplace.ad_renewal_price_mxn', 49);
-        $days = (int) config('marketplace.ad_renewal_days', 7);
-        $count = 0;
-
+        $expiredCount = 0;
         foreach ($expiredAds as $ad) {
             DB::table('ads')->where('id', $ad->id)->update([
                 'status' => 'expired',
                 'updated_at' => now(),
             ]);
 
-            $notificationData = [
-                'user_id' => $ad->user_id,
-                'title' => 'Tu anuncio expiró',
-                'message' => "Tu anuncio \"{$ad->title}\" expiró. Renuévalo por {$days} días por $" . number_format($amount, 0) . ' MXN o elimínalo sin costo.',
-                'is_read' => false,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ];
-            DB::table('user_notifications')->insert($notificationData);
+            $this->notifySeller(
+                $ad,
+                'expired',
+                'Tu anuncio dejó de mostrarse',
+                "Tu anuncio \"{$ad->title}\" ya no está visible. Renuévalo ahora por {$renewalDays} días por $" . number_format($amount, 0) . ' MXN para recuperar visitas y contactos.',
+                "Tu anuncio \"{$ad->title}\" dejó de mostrarse — recupéralo hoy"
+            );
 
-            if ($ad->user && $ad->user->email) {
-                try {
-                    Mail::raw(
-                        "Hola {$ad->user->name},\n\nTu anuncio \"{$ad->title}\" en Mercasto ha expirado.\n\nPuedes renovarlo por {$days} días pagando $" . number_format($amount, 0) . " MXN desde tu perfil, o eliminarlo sin costo.\n\nhttps://mercasto.com/profile",
-                        function ($message) use ($ad) {
-                            $message->to($ad->user->email)
-                                ->subject("Tu anuncio \"{$ad->title}\" expiró");
-                        }
-                    );
-                } catch (\Throwable $error) {
-                    \Illuminate\Support\Facades\Log::warning(
-                        "ExpireAds: could not send email for ad #{$ad->id}: " . $error->getMessage()
-                    );
-                }
+            $expiredCount++;
+        }
+
+        if ($expiredCount > 0) {
+            Cache::forget('sitemap_xml');
+            Cache::forget('google_merchant_xml');
+            Cache::forget('ads_featured_block');
+            for ($page = 1; $page <= 10; $page++) {
+                Cache::forget("ads_index_page_{$page}");
+            }
+        }
+
+        $this->info("Warnings sent: {$warningCount}. Expired ads: {$expiredCount}.");
+        return self::SUCCESS;
+    }
+
+    private function sendExpiryWarnings(float $amount, int $renewalDays): int
+    {
+        $ads = Ad::with('user:id,name,email')
+            ->where('status', 'active')
+            ->where('is_catalog_filler', false)
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '>', now())
+            ->where('expires_at', '<=', now()->addDays(3))
+            ->get();
+
+        $sent = 0;
+        foreach ($ads as $ad) {
+            $hours = max(1, now()->diffInHours($ad->expires_at, false));
+            $stage = $hours <= 24 ? '24h' : '72h';
+            $cacheKey = "seller_lifecycle:ad:{$ad->id}:{$stage}:" . $ad->expires_at->timestamp;
+
+            if (! Cache::add($cacheKey, true, now()->addDays(14))) {
+                continue;
             }
 
-            $count++;
+            if ($stage === '24h') {
+                $title = 'Últimas horas para mantener tu anuncio visible';
+                $message = "Tu anuncio \"{$ad->title}\" vence en menos de 24 horas. Renuévalo por $" . number_format($amount, 0) . " MXN y conserva tus visitas, favoritos y oportunidades de contacto.";
+                $subject = "Últimas horas: tu anuncio \"{$ad->title}\" está por vencer";
+            } else {
+                $title = 'Tu anuncio vence pronto';
+                $message = "A tu anuncio \"{$ad->title}\" le quedan menos de 3 días. Renuévalo por {$renewalDays} días por $" . number_format($amount, 0) . ' MXN para seguir apareciendo ante compradores.';
+                $subject = "Tu anuncio \"{$ad->title}\" vence en 3 días";
+            }
+
+            $this->notifySeller($ad, $stage, $title, $message, $subject);
+            $sent++;
         }
 
-        Cache::forget('sitemap_xml');
-        Cache::forget('google_merchant_xml');
-        Cache::forget('ads_featured_block');
-        for ($page = 1; $page <= 10; $page++) {
-            Cache::forget("ads_index_page_{$page}");
+        return $sent;
+    }
+
+    private function notifySeller(Ad $ad, string $stage, string $title, string $message, string $subject): void
+    {
+        DB::table('user_notifications')->insert([
+            'user_id' => $ad->user_id,
+            'title' => $title,
+            'message' => $message . ' Abre tu perfil y pulsa “Renovar”.',
+            'is_read' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        if (! $ad->user?->email) {
+            return;
         }
 
-        $this->info("Expired {$count} ads.");
-        return self::SUCCESS;
+        try {
+            Mail::raw(
+                "Hola {$ad->user->name},\n\n{$message}\n\nRenueva desde tu perfil:\nhttps://mercasto.com/profile\n\nConsejo Mercasto: los anuncios activos y actualizados reciben más oportunidades de contacto.\n\nEquipo Mercasto",
+                function ($mail) use ($ad, $subject) {
+                    $mail->to($ad->user->email)->subject($subject);
+                }
+            );
+        } catch (\Throwable $error) {
+            Log::warning('Seller lifecycle email failed', [
+                'ad_id' => $ad->id,
+                'stage' => $stage,
+                'error' => $error->getMessage(),
+            ]);
+        }
     }
 }

--- a/src/components/BuyerConversionNudge.jsx
+++ b/src/components/BuyerConversionNudge.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { MessageCircle, ShieldCheck, X } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const STORAGE_KEY = 'mercasto.buyer_conversion_nudge.dismissed_at';
+const DISMISS_FOR_MS = 24 * 60 * 60 * 1000;
+
+export default function BuyerConversionNudge() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const hasSession = Boolean(localStorage.getItem('auth_token'));
+    const hiddenRoute = ['/login', '/register', '/post', '/profile', '/admin'].some((path) =>
+      location.pathname.startsWith(path)
+    );
+    const dismissedAt = Number(localStorage.getItem(STORAGE_KEY) || 0);
+    const recentlyDismissed = Date.now() - dismissedAt < DISMISS_FOR_MS;
+
+    if (hasSession || hiddenRoute || recentlyDismissed) {
+      setVisible(false);
+      return undefined;
+    }
+
+    const timer = window.setTimeout(() => setVisible(true), 4500);
+    return () => window.clearTimeout(timer);
+  }, [location.pathname]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now()));
+    setVisible(false);
+  };
+
+  const register = () => {
+    try {
+      sessionStorage.setItem('mercasto.buyer_registration_intent', location.pathname + location.search);
+    } catch {}
+    window.dispatchEvent(new CustomEvent('mercasto:open-auth', { detail: { mode: 'register' } }));
+    navigate(location.pathname, { replace: true });
+  };
+
+  return (
+    <aside className="fixed inset-x-3 bottom-3 z-[100] mx-auto max-w-xl rounded-2xl border border-lime-300 bg-slate-950 p-4 text-white shadow-2xl md:bottom-6 md:p-5" role="dialog" aria-label="Beneficios para compradores">
+      <button type="button" onClick={dismiss} className="absolute right-3 top-3 rounded-full p-1 text-slate-400 hover:bg-white/10 hover:text-white" aria-label="Cerrar">
+        <X className="h-5 w-5" />
+      </button>
+      <div className="pr-8">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-lime-300">Compra directo, sin comisión</p>
+        <h2 className="mt-1 text-lg font-black leading-tight">Regístrate gratis y habla directamente con los vendedores</h2>
+        <div className="mt-3 grid gap-2 text-sm text-slate-200 sm:grid-cols-2">
+          <span className="flex items-center gap-2"><MessageCircle className="h-4 w-4 text-lime-300" /> Contacta por WhatsApp o Telegram</span>
+          <span className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-lime-300" /> Guarda favoritos y vuelve cuando quieras</span>
+        </div>
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+          <button type="button" onClick={register} className="rounded-xl bg-lime-400 px-5 py-3 text-sm font-black text-slate-950 hover:bg-lime-300">Crear cuenta gratis</button>
+          <button type="button" onClick={dismiss} className="rounded-xl border border-white/20 px-5 py-3 text-sm font-bold text-white hover:bg-white/10">Seguir explorando</button>
+        </div>
+        <p className="mt-2 text-[11px] text-slate-400">Mercasto no cobra comisión por contactar al vendedor. Verifica siempre el producto y acuerda una entrega segura.</p>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/BuyerConversionNudge.jsx
+++ b/src/components/BuyerConversionNudge.jsx
@@ -38,8 +38,8 @@ export default function BuyerConversionNudge() {
     try {
       sessionStorage.setItem('mercasto.buyer_registration_intent', location.pathname + location.search);
     } catch {}
-    window.dispatchEvent(new CustomEvent('mercasto:open-auth', { detail: { mode: 'register' } }));
-    navigate(location.pathname, { replace: true });
+    setVisible(false);
+    navigate('/post', { state: { authMode: 'register', buyerIntent: true } });
   };
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import AppWrapper from './App.jsx'
 import AdminModerationCenter from './components/admin/AdminModerationCenter.jsx'
+import BuyerConversionNudge from './components/BuyerConversionNudge.jsx'
 import { UIProvider } from './contexts/UIContext.jsx'
 import { ToastProvider } from './components/ui/Toast.jsx'
 import { initBehaviorAnalytics } from './utils/analytics'
@@ -38,6 +39,7 @@ if (rootElement) {
         <ToastProvider>
           <BrowserRouter>
             <AppWrapper />
+            <BuyerConversionNudge />
             {/* Keep moderation inside the shared router/provider tree so it reuses the authenticated admin session. */}
             <AdminModerationCenter />
           </BrowserRouter>


### PR DESCRIPTION
## Summary

- Adds a seller lifecycle notification sequence for normal customer ads:
  - warning under 3 days before expiry;
  - urgent warning under 24 hours;
  - recovery message immediately after the ad stops being visible.
- Sends every seller reminder both in the Mercasto notification center and by email.
- Uses cache-backed stage keys so the scheduled command cannot repeatedly send the same reminder for the same expiry date.
- Keeps catalog filler ads excluded from expiry marketing.
- Adds a prominent but dismissible buyer conversion panel for anonymous visitors.
- Communicates the central buyer value proposition: free registration, no Mercasto contact commission, direct WhatsApp/Telegram contact, and saved favorites.
- Routes the registration CTA through Mercasto’s existing protected authentication flow rather than creating a separate registration implementation.

## Marketing strategy

The seller copy avoids generic reminders and frames renewal around the outcome sellers care about: preserving visibility, visits, favorites, and direct contact opportunities. Urgency increases as expiry approaches, while the post-expiry message focuses on recovering lost exposure.

The buyer prompt appears only after browsing for 4.5 seconds, stays hidden on authentication/profile/admin/publication routes, disappears for authenticated users, and respects a 24-hour dismissal so it remains noticeable without becoming spammy.

## Risk

- Email delivery remains non-blocking; failures are logged without stopping ad expiry.
- Reminder deduplication uses the ad ID, stage, and exact expiry timestamp, so a paid renewal naturally creates a fresh lifecycle.
- The buyer CTA uses the existing `/post` auth gate; no new authentication endpoint or credential handling is introduced.
- Copy is currently Spanish-first, matching the primary Mexico market. Full 13-locale translation can be layered on after conversion behavior is validated.

## Smoke

1. Run `php artisan ads:expire` with a customer ad expiring in 2–3 days and confirm one in-app notification and one email.
2. Run it again and confirm the 72-hour notification is not duplicated.
3. Move expiry under 24 hours and confirm the urgent notification is sent once.
4. Expire the ad and confirm status changes to `expired` plus the recovery notification/email.
5. Confirm catalog filler ads receive none of these messages.
6. Visit a public page while signed out and confirm the buyer panel appears after 4.5 seconds.
7. Dismiss it and confirm it stays hidden for 24 hours.
8. Click `Crear cuenta gratis` and confirm Mercasto opens the existing auth-protected flow.
9. Run frontend lint/build and backend PHP syntax/tests.

## Rollback

Revert this pull request. No migration, payment configuration, user data rewrite, or subscription state change is involved.