### PR TITLE
Send seller acquisition traffic directly to /post

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -19,6 +19,16 @@ import { installStaleChunkRecovery } from './utils/staleChunkRecovery'
 import './index.css'
 import './i18n'; // Multi-language support
 
+// Seller acquisition traffic must enter the publication flow directly.
+// Preserve query/hash attribution while removing the obsolete landing-page hop.
+if (['/vendedores', '/publicar-gratis'].includes(window.location.pathname)) {
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `/post${window.location.search}${window.location.hash}`,
+  );
+}
+
 // Install acquisition attribution before analytics bridges so every downstream
 // event keeps its campaign context across registration and SPA navigation.
 installCampaignAttribution();


### PR DESCRIPTION
## Что изменено
- `/vendedores` и `/publicar-gratis` перенаправляются на `/post` до запуска React Router.
- UTM/query/hash параметры сохраняются.
- Пользователь сразу попадает в существующий защищённый поток публикации и после регистрации возвращается к созданию объявления.

## Зачем
Убирает лишнюю посадочную страницу из рекламной воронки Meta/TikTok и из старых CTA, которые ещё используют `/vendedores`.