### PR TITLE
Add Advertising Hub foundation

### DIFF
--- a/docs/advertising-hub.md
+++ b/docs/advertising-hub.md
@@ -1,0 +1,125 @@
+# Mercasto Advertising Hub
+
+## Goal
+
+Provide one internal marketing control plane for paid acquisition, measurement, creative management, budgets and automation across Meta, TikTok, Google, X and Microsoft.
+
+## UI
+
+The first admin entry point is `/admin/marketing`.
+
+Modules:
+
+- Dashboard
+- Connections
+- Campaigns
+- Creatives
+- Audiences
+- Pixels / Tracking
+- Budgets
+- A/B Tests
+- Automations
+- AI Analyst
+- Reports
+
+## Integration boundary
+
+Platform SDKs and API payloads must not be used directly by UI components. Each provider implements the same adapter contract.
+
+```text
+AdvertisingHub
+  -> Marketing API
+      -> Campaign service
+      -> Metrics service
+      -> Attribution service
+      -> Automation engine
+      -> Provider adapters
+          -> Meta
+          -> TikTok
+          -> Google Ads
+          -> Merchant Center
+          -> GA4 / GTM
+          -> X Ads
+          -> Microsoft Ads
+```
+
+## Canonical entities
+
+- `marketing_connections`
+- `marketing_accounts`
+- `marketing_campaigns`
+- `marketing_ad_groups`
+- `marketing_ads`
+- `marketing_creatives`
+- `marketing_audiences`
+- `marketing_daily_metrics`
+- `marketing_conversion_events`
+- `marketing_budget_rules`
+- `marketing_automation_rules`
+- `marketing_sync_runs`
+
+Provider IDs are stored as external references. Mercasto IDs remain the canonical identifiers used by the UI and automation engine.
+
+## Canonical metrics
+
+- spend
+- impressions
+- reach
+- clicks
+- ctr
+- cpc
+- cpm
+- registrations
+- published_ads
+- add_to_cart
+- checkout_started
+- purchases
+- revenue
+- cpa_registration
+- cpa_publication
+- roas
+
+All money values must include currency. Reporting must never combine different currencies without an explicit conversion layer.
+
+## Adapter contract
+
+Each advertising provider should implement:
+
+- connect / refresh credentials
+- list accounts
+- import campaigns
+- create campaign
+- create ad group
+- create ad
+- upload creative
+- pause / resume
+- update budget
+- fetch metrics
+- validate tracking
+- normalize provider errors
+
+Read and write capabilities are declared separately because some APIs or accounts may only support reporting.
+
+## Security
+
+- Credentials are encrypted server-side and never returned to the browser.
+- OAuth states are signed and short-lived.
+- Every write action is audited.
+- Provider webhooks are signature-validated and idempotent.
+- Budget changes require configurable limits.
+- Automation rules support dry-run mode and rollback metadata.
+
+## Delivery order
+
+1. Foundation UI and canonical architecture.
+2. Meta account connection and metrics import.
+3. Registration and PostAd conversion dashboard.
+4. Campaign pause/resume and budget updates.
+5. TikTok reconnect and adapter.
+6. Google Ads, Merchant Center, GA4 and GTM.
+7. X Ads and Microsoft Ads.
+8. Automated rules, A/B tests and AI recommendations.
+
+## Current status
+
+The foundation UI exists as an admin-only overlay at `/admin/marketing`. It intentionally displays placeholders until backend endpoints and provider adapters are implemented.

--- a/src/components/admin/AdvertisingHub.jsx
+++ b/src/components/admin/AdvertisingHub.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   BarChart3,
@@ -53,9 +53,10 @@ const statusClass = {
 export default function AdvertisingHub() {
   const location = useLocation();
   const navigate = useNavigate();
-  const isAdmin = useMemo(readAdmin, [location.pathname]);
+  const [isAdmin] = useState(readAdmin);
   const visible = isAdmin && location.pathname.startsWith('/admin/marketing');
   const activeSection = new URLSearchParams(location.search).get('section') || 'dashboard';
+  const activeSectionInfo = sections.find((item) => item.id === activeSection) || sections[0];
 
   if (!visible) return null;
 
@@ -127,8 +128,8 @@ export default function AdvertisingHub() {
             </section>
 
             <section className="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-8 text-center dark:border-slate-700 dark:bg-slate-900/60">
-              <h2 className="text-xl font-black text-slate-900 dark:text-white">{sections.find((item) => item.id === activeSection)?.label || 'Dashboard'}</h2>
-              <p className="mx-auto mt-2 max-w-xl text-sm text-slate-500">{sections.find((item) => item.id === activeSection)?.description}. This foundation is ready for API-backed modules without coupling platform-specific logic to the interface.</p>
+              <h2 className="text-xl font-black text-slate-900 dark:text-white">{activeSectionInfo.label}</h2>
+              <p className="mx-auto mt-2 max-w-xl text-sm text-slate-500">{activeSectionInfo.description} This foundation is ready for API-backed modules without coupling platform-specific logic to the interface.</p>
             </section>
           </main>
         </div>

--- a/src/components/admin/AdvertisingHub.jsx
+++ b/src/components/admin/AdvertisingHub.jsx
@@ -1,0 +1,138 @@
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  BarChart3,
+  Bot,
+  CircleDollarSign,
+  FlaskConical,
+  Image,
+  Megaphone,
+  PlugZap,
+  RadioTower,
+  Settings2,
+  Users,
+} from 'lucide-react';
+
+const readAdmin = () => {
+  try {
+    return JSON.parse(localStorage.getItem('user') || '{}')?.role === 'admin';
+  } catch {
+    return false;
+  }
+};
+
+const sections = [
+  { id: 'dashboard', label: 'Dashboard', icon: BarChart3, description: 'Resultados de todas las plataformas.' },
+  { id: 'connections', label: 'Connections', icon: PlugZap, description: 'Meta, TikTok, Google, X y Microsoft.' },
+  { id: 'campaigns', label: 'Campaigns', icon: Megaphone, description: 'Campañas, conjuntos y anuncios.' },
+  { id: 'creatives', label: 'Creatives', icon: Image, description: 'Imágenes, videos, textos y variantes.' },
+  { id: 'audiences', label: 'Audiences', icon: Users, description: 'Segmentos y públicos sincronizados.' },
+  { id: 'tracking', label: 'Pixels', icon: RadioTower, description: 'Píxeles, CAPI, eventos y UTM.' },
+  { id: 'budgets', label: 'Budgets', icon: CircleDollarSign, description: 'Presupuestos y reglas de distribución.' },
+  { id: 'tests', label: 'A/B Tests', icon: FlaskConical, description: 'Pruebas entre creativos y audiencias.' },
+  { id: 'automations', label: 'Automations', icon: Settings2, description: 'Pausas, escalado y alertas automáticas.' },
+  { id: 'ai', label: 'AI Analyst', icon: Bot, description: 'Análisis diario y recomendaciones.' },
+];
+
+const platforms = [
+  { name: 'Meta Ads', status: 'ready', detail: 'Facebook + Instagram' },
+  { name: 'TikTok Ads', status: 'attention', detail: 'Reconnect advertiser account' },
+  { name: 'Google Ads', status: 'planned', detail: 'API adapter planned' },
+  { name: 'Merchant Center', status: 'planned', detail: 'Product feed planned' },
+  { name: 'GA4 + GTM', status: 'planned', detail: 'Measurement adapter planned' },
+  { name: 'X Ads', status: 'planned', detail: 'API access required' },
+  { name: 'Microsoft Ads', status: 'planned', detail: 'API adapter planned' },
+];
+
+const statusClass = {
+  ready: 'bg-lime-100 text-lime-800',
+  attention: 'bg-amber-100 text-amber-800',
+  planned: 'bg-slate-100 text-slate-600',
+};
+
+export default function AdvertisingHub() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isAdmin = useMemo(readAdmin, [location.pathname]);
+  const visible = isAdmin && location.pathname.startsWith('/admin/marketing');
+  const activeSection = new URLSearchParams(location.search).get('section') || 'dashboard';
+
+  if (!visible) return null;
+
+  const setSection = (section) => navigate(`/admin/marketing?section=${section}`, { replace: true });
+
+  return (
+    <div className="fixed inset-0 z-[90] overflow-y-auto bg-slate-100 dark:bg-slate-950">
+      <div className="mx-auto min-h-screen max-w-[1600px] px-4 py-5 md:px-7">
+        <header className="mb-5 flex flex-wrap items-center justify-between gap-4 rounded-3xl bg-slate-950 px-5 py-5 text-white shadow-xl">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.24em] text-lime-400">Mercasto Marketing</p>
+            <h1 className="mt-1 text-2xl font-black md:text-3xl">Advertising Hub</h1>
+            <p className="mt-1 max-w-2xl text-sm text-slate-300">Una sola consola para campañas, medición, presupuestos y automatización multiplataforma.</p>
+          </div>
+          <button type="button" onClick={() => navigate('/admin')} className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold hover:bg-slate-800">Volver al admin</button>
+        </header>
+
+        <div className="grid gap-5 lg:grid-cols-[270px_1fr]">
+          <aside className="rounded-3xl bg-white p-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+            <nav className="space-y-1">
+              {sections.map(({ id, label, icon: Icon }) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setSection(id)}
+                  className={`flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left text-sm font-extrabold transition ${activeSection === id ? 'bg-lime-400 text-slate-950' : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'}`}
+                >
+                  <Icon className="h-5 w-5" />
+                  {label}
+                </button>
+              ))}
+            </nav>
+          </aside>
+
+          <main className="space-y-5">
+            <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {[
+                ['Spend today', '—', 'Awaiting unified metrics'],
+                ['Registrations', '—', 'Meta + TikTok attribution'],
+                ['Published ads', '—', 'PostAd conversion'],
+                ['ROAS', '—', 'Purchases and paid renewals'],
+              ].map(([label, value, detail]) => (
+                <article key={label} className="rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+                  <p className="text-xs font-black uppercase tracking-wider text-slate-500">{label}</p>
+                  <p className="mt-2 text-3xl font-black text-slate-950 dark:text-white">{value}</p>
+                  <p className="mt-2 text-xs text-slate-500">{detail}</p>
+                </article>
+              ))}
+            </section>
+
+            <section className="rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+              <div className="mb-4">
+                <h2 className="text-xl font-black text-slate-950 dark:text-white">Platform connections</h2>
+                <p className="text-sm text-slate-500">Adapters share one internal campaign and metrics model.</p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {platforms.map((platform) => (
+                  <article key={platform.name} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-black text-slate-900 dark:text-white">{platform.name}</h3>
+                        <p className="mt-1 text-xs text-slate-500">{platform.detail}</p>
+                      </div>
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-black uppercase ${statusClass[platform.status]}`}>{platform.status}</span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-8 text-center dark:border-slate-700 dark:bg-slate-900/60">
+              <h2 className="text-xl font-black text-slate-900 dark:text-white">{sections.find((item) => item.id === activeSection)?.label || 'Dashboard'}</h2>
+              <p className="mx-auto mt-2 max-w-xl text-sm text-slate-500">{sections.find((item) => item.id === activeSection)?.description}. This foundation is ready for API-backed modules without coupling platform-specific logic to the interface.</p>
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import AppWrapper from './App.jsx'
 import AdminModerationCenter from './components/admin/AdminModerationCenter.jsx'
+import AdvertisingHub from './components/admin/AdvertisingHub.jsx'
 import { UIProvider } from './contexts/UIContext.jsx'
 import { ToastProvider } from './components/ui/Toast.jsx'
 import { initBehaviorAnalytics } from './utils/analytics'
@@ -48,8 +49,9 @@ if (rootElement) {
         <ToastProvider>
           <BrowserRouter>
             <AppWrapper />
-            {/* Keep moderation inside the shared router/provider tree so it reuses the authenticated admin session. */}
+            {/* Keep admin overlays inside the shared router/provider tree so they reuse the authenticated admin session. */}
             <AdminModerationCenter />
+            <AdvertisingHub />
           </BrowserRouter>
         </ToastProvider>
       </UIProvider>


### PR DESCRIPTION
## Summary
- add an admin-only Advertising Hub at `/admin/marketing`
- add navigation for dashboard, connections, campaigns, creatives, audiences, tracking, budgets, A/B tests, automations and AI analysis
- show initial provider readiness for Meta, TikTok, Google, X and Microsoft
- document the canonical architecture, entities, metrics, adapter contract, security rules and delivery order

## Risk
Low. This is a frontend-only admin overlay. It is rendered only for users whose stored role is `admin`, does not replace public routes, and does not yet perform provider API writes.

## Smoke
- open `/admin/marketing` as an authenticated admin
- verify navigation between sections through the `section` query parameter
- verify `/admin` remains reachable
- verify non-admin users do not see the overlay
- run `npm run lint:ci`
- run `npm run build`

## Rollback
Revert the commits in this pull request. This removes the Advertising Hub component, its mount in `src/main.jsx`, and the architecture document without requiring data migration or credential changes.

## Scope
This PR intentionally creates the frontend and architecture foundation only. Provider credentials and live metrics remain server-side follow-up work.