### PR TITLE
Add Meta Ads reporting API and dashboard integration

### DIFF
--- a/backend/app/Http/Controllers/Api/MarketingController.php
+++ b/backend/app/Http/Controllers/Api/MarketingController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\MetaMarketingService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use RuntimeException;
+
+class MarketingController extends Controller
+{
+    public function metaStatus(Request $request, MetaMarketingService $meta): JsonResponse
+    {
+        $this->ensureAdmin($request);
+
+        return response()->json(['provider' => 'meta', ...$meta->status()]);
+    }
+
+    public function metaCampaigns(Request $request, MetaMarketingService $meta): JsonResponse
+    {
+        $this->ensureAdmin($request);
+
+        $validated = $request->validate([
+            'days' => ['nullable', 'integer', 'min:1', 'max:90'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        try {
+            return response()->json([
+                'provider' => 'meta',
+                ...$meta->campaigns((int) ($validated['days'] ?? 7), (int) ($validated['limit'] ?? 50)),
+            ]);
+        } catch (RuntimeException $exception) {
+            report($exception);
+
+            return response()->json([
+                'provider' => 'meta',
+                'error' => $exception->getMessage(),
+            ], str_contains($exception->getMessage(), 'not configured') ? 503 : 502);
+        }
+    }
+
+    private function ensureAdmin(Request $request): void
+    {
+        abort_unless($request->user()?->role === 'admin', 403, 'Acceso denegado');
+    }
+}

--- a/backend/app/Services/MetaMarketingService.php
+++ b/backend/app/Services/MetaMarketingService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class MetaMarketingService
+{
+    private string $graphVersion;
+    private ?string $accessToken;
+    private ?string $adAccountId;
+
+    public function __construct()
+    {
+        $this->graphVersion = (string) config('services.facebook.graph_version', 'v25.0');
+        $this->accessToken = config('services.facebook.marketing_access_token') ?: config('services.facebook.access_token');
+        $this->adAccountId = config('services.facebook.ad_account_id');
+    }
+
+    public function status(): array
+    {
+        return [
+            'configured' => filled($this->accessToken) && filled($this->adAccountId),
+            'ad_account_id' => $this->adAccountId ? $this->normalizeAccountId($this->adAccountId) : null,
+            'graph_version' => $this->graphVersion,
+            'capabilities' => [
+                'read_campaigns' => filled($this->accessToken) && filled($this->adAccountId),
+                'read_insights' => filled($this->accessToken) && filled($this->adAccountId),
+                'write_campaigns' => false,
+            ],
+        ];
+    }
+
+    public function campaigns(int $days = 7, int $limit = 50): array
+    {
+        $this->ensureConfigured();
+
+        $since = now('America/Mexico_City')->subDays(max(1, min(90, $days)) - 1)->toDateString();
+        $until = now('America/Mexico_City')->toDateString();
+        $accountId = $this->normalizeAccountId((string) $this->adAccountId);
+
+        $response = $this->client()->get("https://graph.facebook.com/{$this->graphVersion}/{$accountId}/campaigns", [
+            'fields' => 'id,name,status,effective_status,objective,daily_budget,lifetime_budget,created_time,updated_time,insights.time_range({"since":"'.$since.'","until":"'.$until.'"}){spend,impressions,reach,clicks,ctr,cpc,cpm,actions,cost_per_action_type}',
+            'limit' => max(1, min(100, $limit)),
+        ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException($response->json('error.message') ?: 'Meta Marketing API request failed.');
+        }
+
+        return [
+            'data' => collect($response->json('data', []))->map(fn (array $campaign) => $this->normalizeCampaign($campaign))->values()->all(),
+            'period' => ['since' => $since, 'until' => $until],
+            'paging' => $response->json('paging', []),
+        ];
+    }
+
+    private function client(): PendingRequest
+    {
+        return Http::acceptJson()
+            ->timeout(20)
+            ->retry(2, 250)
+            ->withToken((string) $this->accessToken);
+    }
+
+    private function ensureConfigured(): void
+    {
+        if (!filled($this->accessToken) || !filled($this->adAccountId)) {
+            throw new RuntimeException('Meta Marketing API is not configured.');
+        }
+    }
+
+    private function normalizeAccountId(string $value): string
+    {
+        return str_starts_with($value, 'act_') ? $value : 'act_'.$value;
+    }
+
+    private function normalizeCampaign(array $campaign): array
+    {
+        $insights = data_get($campaign, 'insights.data.0', []);
+        $actions = collect($insights['actions'] ?? [])->pluck('value', 'action_type');
+        $costs = collect($insights['cost_per_action_type'] ?? [])->pluck('value', 'action_type');
+
+        return [
+            'id' => (string) ($campaign['id'] ?? ''),
+            'name' => (string) ($campaign['name'] ?? ''),
+            'status' => $campaign['status'] ?? null,
+            'effective_status' => $campaign['effective_status'] ?? null,
+            'objective' => $campaign['objective'] ?? null,
+            'daily_budget' => isset($campaign['daily_budget']) ? ((float) $campaign['daily_budget']) / 100 : null,
+            'lifetime_budget' => isset($campaign['lifetime_budget']) ? ((float) $campaign['lifetime_budget']) / 100 : null,
+            'currency' => 'MXN',
+            'created_time' => $campaign['created_time'] ?? null,
+            'updated_time' => $campaign['updated_time'] ?? null,
+            'metrics' => [
+                'spend' => (float) ($insights['spend'] ?? 0),
+                'impressions' => (int) ($insights['impressions'] ?? 0),
+                'reach' => (int) ($insights['reach'] ?? 0),
+                'clicks' => (int) ($insights['clicks'] ?? 0),
+                'ctr' => (float) ($insights['ctr'] ?? 0),
+                'cpc' => (float) ($insights['cpc'] ?? 0),
+                'cpm' => (float) ($insights['cpm'] ?? 0),
+                'registrations' => (int) ($actions['complete_registration'] ?? 0),
+                'leads' => (int) ($actions['lead'] ?? 0),
+                'purchases' => (int) ($actions['purchase'] ?? 0),
+                'cost_per_registration' => isset($costs['complete_registration']) ? (float) $costs['complete_registration'] : null,
+            ],
+        ];
+    }
+}

--- a/backend/app/Services/MetaMarketingService.php
+++ b/backend/app/Services/MetaMarketingService.php
@@ -14,9 +14,9 @@ class MetaMarketingService
 
     public function __construct()
     {
-        $this->graphVersion = (string) config('services.facebook.graph_version', 'v25.0');
-        $this->accessToken = config('services.facebook.marketing_access_token') ?: config('services.facebook.access_token');
-        $this->adAccountId = config('services.facebook.ad_account_id');
+        $this->graphVersion = (string) config('marketing.meta.graph_version', 'v25.0');
+        $this->accessToken = config('marketing.meta.access_token');
+        $this->adAccountId = config('marketing.meta.ad_account_id');
     }
 
     public function status(): array

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -19,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
         then: function () {
             Route::middleware(['api', 'auth:sanctum'])->delete('/api/user', [AccountDeletionController::class, 'delete']);
+            require base_path('routes/marketing.php');
         },
     )
     ->withMiddleware(function (Middleware $middleware) use ($trustedProxies) {

--- a/backend/config/marketing.php
+++ b/backend/config/marketing.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'meta' => [
+        'ad_account_id' => env('META_AD_ACCOUNT_ID'),
+        'access_token' => env('META_MARKETING_ACCESS_TOKEN', env('FACEBOOK_ACCESS_TOKEN')),
+        'graph_version' => env('FACEBOOK_GRAPH_VERSION', 'v25.0'),
+    ],
+];

--- a/backend/routes/marketing.php
+++ b/backend/routes/marketing.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\Api\MarketingController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['api', 'auth:sanctum', 'throttle:api'])
+    ->prefix('api/admin/marketing')
+    ->group(function () {
+        Route::get('/meta/status', [MarketingController::class, 'metaStatus']);
+        Route::get('/meta/campaigns', [MarketingController::class, 'metaCampaigns']);
+    });

--- a/src/components/admin/AdvertisingHub.jsx
+++ b/src/components/admin/AdvertisingHub.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   BarChart3,
@@ -9,9 +9,12 @@ import {
   Megaphone,
   PlugZap,
   RadioTower,
+  RefreshCw,
   Settings2,
   Users,
 } from 'lucide-react';
+
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'https://mercasto.com/api';
 
 const readAdmin = () => {
   try {
@@ -34,8 +37,7 @@ const sections = [
   { id: 'ai', label: 'AI Analyst', icon: Bot, description: 'Análisis diario y recomendaciones.' },
 ];
 
-const platforms = [
-  { name: 'Meta Ads', status: 'ready', detail: 'Facebook + Instagram' },
+const staticPlatforms = [
   { name: 'TikTok Ads', status: 'attention', detail: 'Reconnect advertiser account' },
   { name: 'Google Ads', status: 'planned', detail: 'API adapter planned' },
   { name: 'Merchant Center', status: 'planned', detail: 'Product feed planned' },
@@ -50,13 +52,91 @@ const statusClass = {
   planned: 'bg-slate-100 text-slate-600',
 };
 
+const money = (value, currency = 'MXN') => new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency,
+  maximumFractionDigits: 2,
+}).format(Number(value || 0));
+
+const number = (value) => new Intl.NumberFormat('es-MX').format(Number(value || 0));
+
 export default function AdvertisingHub() {
   const location = useLocation();
   const navigate = useNavigate();
   const [isAdmin] = useState(readAdmin);
+  const [metaStatus, setMetaStatus] = useState(null);
+  const [campaigns, setCampaigns] = useState([]);
+  const [period, setPeriod] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
   const visible = isAdmin && location.pathname.startsWith('/admin/marketing');
   const activeSection = new URLSearchParams(location.search).get('section') || 'dashboard';
   const activeSectionInfo = sections.find((item) => item.id === activeSection) || sections[0];
+
+  const loadMeta = useCallback(async () => {
+    const token = localStorage.getItem('auth_token');
+    if (!token) {
+      setError('No hay una sesión administrativa activa.');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const headers = { Accept: 'application/json', Authorization: `Bearer ${token}` };
+      const statusResponse = await fetch(`${API_URL}/admin/marketing/meta/status`, { headers });
+      const statusPayload = await statusResponse.json();
+
+      if (!statusResponse.ok) {
+        throw new Error(statusPayload.message || statusPayload.error || 'No se pudo comprobar Meta Ads.');
+      }
+
+      setMetaStatus(statusPayload);
+
+      if (!statusPayload.configured) {
+        setCampaigns([]);
+        setPeriod(null);
+        return;
+      }
+
+      const campaignsResponse = await fetch(`${API_URL}/admin/marketing/meta/campaigns?days=7&limit=50`, { headers });
+      const campaignsPayload = await campaignsResponse.json();
+
+      if (!campaignsResponse.ok) {
+        throw new Error(campaignsPayload.message || campaignsPayload.error || 'No se pudieron cargar las campañas de Meta.');
+      }
+
+      setCampaigns(campaignsPayload.data || []);
+      setPeriod(campaignsPayload.period || null);
+    } catch (requestError) {
+      setError(requestError.message || 'Error al cargar Meta Ads.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (visible) loadMeta();
+  }, [loadMeta, visible]);
+
+  const totals = useMemo(() => campaigns.reduce((accumulator, campaign) => {
+    const metrics = campaign.metrics || {};
+    accumulator.spend += Number(metrics.spend || 0);
+    accumulator.impressions += Number(metrics.impressions || 0);
+    accumulator.clicks += Number(metrics.clicks || 0);
+    accumulator.registrations += Number(metrics.registrations || 0);
+    accumulator.purchases += Number(metrics.purchases || 0);
+    return accumulator;
+  }, { spend: 0, impressions: 0, clicks: 0, registrations: 0, purchases: 0 }), [campaigns]);
+
+  const metaPlatform = {
+    name: 'Meta Ads',
+    status: metaStatus?.configured ? 'ready' : 'attention',
+    detail: metaStatus?.configured
+      ? `${metaStatus.ad_account_id} · ${metaStatus.graph_version}`
+      : 'Faltan credenciales del servidor',
+  };
 
   if (!visible) return null;
 
@@ -71,19 +151,20 @@ export default function AdvertisingHub() {
             <h1 className="mt-1 text-2xl font-black md:text-3xl">Advertising Hub</h1>
             <p className="mt-1 max-w-2xl text-sm text-slate-300">Una sola consola para campañas, medición, presupuestos y automatización multiplataforma.</p>
           </div>
-          <button type="button" onClick={() => navigate('/admin')} className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold hover:bg-slate-800">Volver al admin</button>
+          <div className="flex gap-2">
+            <button type="button" onClick={loadMeta} disabled={loading} className="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold hover:bg-slate-800 disabled:opacity-50">
+              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              Actualizar
+            </button>
+            <button type="button" onClick={() => navigate('/admin')} className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold hover:bg-slate-800">Volver al admin</button>
+          </div>
         </header>
 
         <div className="grid gap-5 lg:grid-cols-[270px_1fr]">
           <aside className="rounded-3xl bg-white p-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
             <nav className="space-y-1">
               {sections.map(({ id, label, icon: Icon }) => (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setSection(id)}
-                  className={`flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left text-sm font-extrabold transition ${activeSection === id ? 'bg-lime-400 text-slate-950' : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'}`}
-                >
+                <button key={id} type="button" onClick={() => setSection(id)} className={`flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left text-sm font-extrabold transition ${activeSection === id ? 'bg-lime-400 text-slate-950' : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'}`}>
                   <Icon className="h-5 w-5" />
                   {label}
                 </button>
@@ -92,16 +173,18 @@ export default function AdvertisingHub() {
           </aside>
 
           <main className="space-y-5">
+            {error && <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">{error}</div>}
+
             <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
               {[
-                ['Spend today', '—', 'Awaiting unified metrics'],
-                ['Registrations', '—', 'Meta + TikTok attribution'],
-                ['Published ads', '—', 'PostAd conversion'],
-                ['ROAS', '—', 'Purchases and paid renewals'],
+                ['Spend · 7 días', money(totals.spend), period ? `${period.since} — ${period.until}` : 'Meta Ads'],
+                ['Registrations', number(totals.registrations), `${number(totals.clicks)} clicks`],
+                ['Impressions', number(totals.impressions), `${campaigns.length} campañas`],
+                ['Purchases', number(totals.purchases), 'Meta attribution'],
               ].map(([label, value, detail]) => (
                 <article key={label} className="rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
                   <p className="text-xs font-black uppercase tracking-wider text-slate-500">{label}</p>
-                  <p className="mt-2 text-3xl font-black text-slate-950 dark:text-white">{value}</p>
+                  <p className="mt-2 text-3xl font-black text-slate-950 dark:text-white">{loading ? '…' : value}</p>
                   <p className="mt-2 text-xs text-slate-500">{detail}</p>
                 </article>
               ))}
@@ -113,7 +196,7 @@ export default function AdvertisingHub() {
                 <p className="text-sm text-slate-500">Adapters share one internal campaign and metrics model.</p>
               </div>
               <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                {platforms.map((platform) => (
+                {[metaPlatform, ...staticPlatforms].map((platform) => (
                   <article key={platform.name} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
                     <div className="flex items-start justify-between gap-3">
                       <div>
@@ -127,10 +210,44 @@ export default function AdvertisingHub() {
               </div>
             </section>
 
-            <section className="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-8 text-center dark:border-slate-700 dark:bg-slate-900/60">
-              <h2 className="text-xl font-black text-slate-900 dark:text-white">{activeSectionInfo.label}</h2>
-              <p className="mx-auto mt-2 max-w-xl text-sm text-slate-500">{activeSectionInfo.description} This foundation is ready for API-backed modules without coupling platform-specific logic to the interface.</p>
-            </section>
+            {(activeSection === 'dashboard' || activeSection === 'campaigns') && (
+              <section className="overflow-hidden rounded-3xl bg-white shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+                <div className="border-b border-slate-200 p-5 dark:border-slate-800">
+                  <h2 className="text-xl font-black text-slate-950 dark:text-white">Meta campaigns</h2>
+                  <p className="text-sm text-slate-500">Resultados normalizados de los últimos 7 días.</p>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead className="bg-slate-50 text-left text-xs uppercase text-slate-500 dark:bg-slate-950">
+                      <tr>
+                        <th className="px-5 py-3">Campaign</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Spend</th><th className="px-5 py-3">Clicks</th><th className="px-5 py-3">CTR</th><th className="px-5 py-3">CPC</th><th className="px-5 py-3">Registrations</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+                      {!loading && campaigns.map((campaign) => (
+                        <tr key={campaign.id}>
+                          <td className="px-5 py-4"><p className="font-bold text-slate-900 dark:text-white">{campaign.name}</p><p className="text-xs text-slate-500">{campaign.objective || campaign.id}</p></td>
+                          <td className="px-5 py-4 text-xs font-bold">{campaign.effective_status || campaign.status || '—'}</td>
+                          <td className="px-5 py-4 font-semibold">{money(campaign.metrics?.spend, campaign.currency || 'MXN')}</td>
+                          <td className="px-5 py-4">{number(campaign.metrics?.clicks)}</td>
+                          <td className="px-5 py-4">{Number(campaign.metrics?.ctr || 0).toFixed(2)}%</td>
+                          <td className="px-5 py-4">{money(campaign.metrics?.cpc, campaign.currency || 'MXN')}</td>
+                          <td className="px-5 py-4">{number(campaign.metrics?.registrations)}</td>
+                        </tr>
+                      ))}
+                      {!loading && campaigns.length === 0 && <tr><td colSpan="7" className="px-5 py-10 text-center text-slate-500">No hay campañas disponibles o Meta todavía no está configurado.</td></tr>}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            )}
+
+            {activeSection !== 'dashboard' && activeSection !== 'campaigns' && (
+              <section className="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-8 text-center dark:border-slate-700 dark:bg-slate-900/60">
+                <h2 className="text-xl font-black text-slate-900 dark:text-white">{activeSectionInfo.label}</h2>
+                <p className="mx-auto mt-2 max-w-xl text-sm text-slate-500">{activeSectionInfo.description} Este módulo se conectará al mismo modelo interno de campañas y métricas.</p>
+              </section>
+            )}
           </main>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a server-side Meta Marketing API client for campaign reporting
- add admin-only endpoints for provider status and campaign metrics
- connect `/admin/marketing` to the new API
- show 7-day spend, impressions, clicks, registrations and purchases
- render a Meta campaigns table with status, spend, clicks, CTR, CPC and registrations
- keep Meta credentials server-side through `META_AD_ACCOUNT_ID` and `META_MARKETING_ACCESS_TOKEN`

## Risk
Medium-low. The API is read-only, requires Sanctum authentication and verifies the `admin` role. The frontend only reads normalized reporting data. No campaign mutation is enabled. External Meta failures are shown as controlled errors.

## Smoke
- set `META_AD_ACCOUNT_ID` and `META_MARKETING_ACCESS_TOKEN` on the backend
- clear Laravel config cache
- authenticate as an admin and open `/admin/marketing`
- verify connection status and 7-day summary cards
- verify the Meta campaigns table loads
- use the refresh button and confirm loading state
- verify non-admin users cannot access the endpoints or overlay
- run `npm run lint:ci`, `npm run build` and backend tests

## Rollback
Revert this pull request. It removes the Meta Marketing service, controller, config, isolated route registration and frontend API integration. No database migration or provider-side mutation is involved.

## Scope
This PR provides read-only reporting. Campaign pause/resume, budget changes, OAuth connection management and persistent sync tables remain follow-up work.