### PR TITLE
Fix Advertising Hub mobile overflow

### DIFF
--- a/src/components/admin/AdvertisingHub.jsx
+++ b/src/components/admin/AdvertisingHub.jsx
@@ -72,6 +72,7 @@ export default function AdvertisingHub() {
   const [budgetDrafts, setBudgetDrafts] = useState({});
   const [error, setError] = useState('');
   const [notice, setNotice] = useState('');
+
   const visible = isAdmin && location.pathname.startsWith('/admin/marketing');
   const activeSection = new URLSearchParams(location.search).get('section') || 'dashboard';
   const activeSectionInfo = sections.find((item) => item.id === activeSection) || sections[0];
@@ -186,9 +187,7 @@ export default function AdvertisingHub() {
   const metaPlatform = {
     name: 'Meta Ads',
     status: metaStatus?.configured ? 'ready' : 'attention',
-    detail: metaStatus?.configured
-      ? `${metaStatus.ad_account_id} · ${metaStatus.graph_version}`
-      : 'Faltan credenciales del servidor',
+    detail: metaStatus?.configured ? `${metaStatus.ad_account_id} · ${metaStatus.graph_version}` : 'Faltan credenciales del servidor',
   };
 
   if (!visible) return null;
@@ -196,68 +195,68 @@ export default function AdvertisingHub() {
   const setSection = (section) => navigate(`/admin/marketing?section=${section}`, { replace: true });
 
   return (
-    <div className="fixed inset-0 z-[90] overflow-y-auto bg-slate-100 dark:bg-slate-950">
-      <div className="mx-auto min-h-screen max-w-[1600px] px-4 py-5 md:px-7">
-        <header className="mb-5 flex flex-wrap items-center justify-between gap-4 rounded-3xl bg-slate-950 px-5 py-5 text-white shadow-xl">
-          <div>
-            <p className="text-xs font-black uppercase tracking-[0.24em] text-lime-400">Mercasto Marketing</p>
-            <h1 className="mt-1 text-2xl font-black md:text-3xl">Advertising Hub</h1>
-            <p className="mt-1 max-w-2xl text-sm text-slate-300">Una sola consola para campañas, medición, presupuestos y automatización multiplataforma.</p>
+    <div className="fixed inset-0 z-[90] overflow-x-hidden overflow-y-auto bg-slate-100 dark:bg-slate-950">
+      <div className="mx-auto min-h-screen w-full max-w-[1600px] overflow-x-hidden px-3 py-4 sm:px-4 sm:py-5 md:px-7">
+        <header className="mb-5 flex min-w-0 flex-wrap items-center justify-between gap-4 rounded-3xl bg-slate-950 px-4 py-5 text-white shadow-xl sm:px-5">
+          <div className="min-w-0 flex-1">
+            <p className="break-words text-xs font-black uppercase tracking-[0.18em] text-lime-400 sm:tracking-[0.24em]">Mercasto Marketing</p>
+            <h1 className="mt-1 break-words text-2xl font-black md:text-3xl">Advertising Hub</h1>
+            <p className="mt-1 max-w-2xl break-words text-sm text-slate-300">Una sola consola para campañas, medición, presupuestos y automatización multiplataforma.</p>
           </div>
-          <div className="flex gap-2">
-            <button type="button" onClick={loadMeta} disabled={loading} className="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold hover:bg-slate-800 disabled:opacity-50">
+          <div className="flex w-full flex-wrap gap-2 sm:w-auto">
+            <button type="button" onClick={loadMeta} disabled={loading} className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-slate-700 px-3 py-2 text-sm font-bold hover:bg-slate-800 disabled:opacity-50 sm:flex-none sm:px-4">
               <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
               Actualizar
             </button>
-            <button type="button" onClick={() => navigate('/admin')} className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-bold hover:bg-slate-800">Volver al admin</button>
+            <button type="button" onClick={() => navigate('/admin')} className="flex-1 rounded-xl border border-slate-700 px-3 py-2 text-sm font-bold hover:bg-slate-800 sm:flex-none sm:px-4">Volver al admin</button>
           </div>
         </header>
 
-        <div className="grid gap-5 lg:grid-cols-[270px_1fr]">
-          <aside className="rounded-3xl bg-white p-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
-            <nav className="space-y-1">
+        <div className="grid min-w-0 gap-5 lg:grid-cols-[270px_minmax(0,1fr)]">
+          <aside className="min-w-0 rounded-3xl bg-white p-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+            <nav className="grid grid-cols-2 gap-1 sm:grid-cols-3 lg:block lg:space-y-1">
               {sections.map(({ id, label, icon: Icon }) => (
-                <button key={id} type="button" onClick={() => setSection(id)} className={`flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left text-sm font-extrabold transition ${activeSection === id ? 'bg-lime-400 text-slate-950' : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'}`}>
-                  <Icon className="h-5 w-5" />
-                  {label}
+                <button key={id} type="button" onClick={() => setSection(id)} className={`flex min-w-0 w-full items-center gap-2 rounded-2xl px-3 py-3 text-left text-xs font-extrabold transition sm:text-sm ${activeSection === id ? 'bg-lime-400 text-slate-950' : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'}`}>
+                  <Icon className="h-5 w-5 shrink-0" />
+                  <span className="truncate">{label}</span>
                 </button>
               ))}
             </nav>
           </aside>
 
-          <main className="space-y-5">
-            {error && <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">{error}</div>}
-            {notice && <div className="rounded-2xl border border-lime-200 bg-lime-50 px-4 py-3 text-sm font-semibold text-lime-800">{notice}</div>}
+          <main className="min-w-0 space-y-5">
+            {error && <div className="break-words rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">{error}</div>}
+            {notice && <div className="break-words rounded-2xl border border-lime-200 bg-lime-50 px-4 py-3 text-sm font-semibold text-lime-800">{notice}</div>}
 
-            <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <section className="grid min-w-0 gap-4 sm:grid-cols-2 xl:grid-cols-4">
               {[
                 ['Spend · 7 días', money(totals.spend), period ? `${period.since} — ${period.until}` : 'Meta Ads'],
                 ['Registrations', number(totals.registrations), `${number(totals.clicks)} clicks`],
                 ['Impressions', number(totals.impressions), `${campaigns.length} campañas`],
                 ['Purchases', number(totals.purchases), 'Meta attribution'],
               ].map(([label, value, detail]) => (
-                <article key={label} className="rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
-                  <p className="text-xs font-black uppercase tracking-wider text-slate-500">{label}</p>
-                  <p className="mt-2 text-3xl font-black text-slate-950 dark:text-white">{loading ? '…' : value}</p>
-                  <p className="mt-2 text-xs text-slate-500">{detail}</p>
+                <article key={label} className="min-w-0 rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+                  <p className="break-words text-xs font-black uppercase tracking-wider text-slate-500">{label}</p>
+                  <p className="mt-2 break-words text-3xl font-black text-slate-950 dark:text-white">{loading ? '…' : value}</p>
+                  <p className="mt-2 break-words text-xs text-slate-500">{detail}</p>
                 </article>
               ))}
             </section>
 
-            <section className="rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
-              <div className="mb-4">
-                <h2 className="text-xl font-black text-slate-950 dark:text-white">Platform connections</h2>
-                <p className="text-sm text-slate-500">Adapters share one internal campaign and metrics model.</p>
+            <section className="min-w-0 rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+              <div className="mb-4 min-w-0">
+                <h2 className="break-words text-xl font-black text-slate-950 dark:text-white">Platform connections</h2>
+                <p className="break-words text-sm text-slate-500">Adapters share one internal campaign and metrics model.</p>
               </div>
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid min-w-0 gap-3 md:grid-cols-2 xl:grid-cols-3">
                 {[metaPlatform, ...staticPlatforms].map((platform) => (
-                  <article key={platform.name} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <h3 className="font-black text-slate-900 dark:text-white">{platform.name}</h3>
-                        <p className="mt-1 text-xs text-slate-500">{platform.detail}</p>
+                  <article key={platform.name} className="min-w-0 rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex min-w-0 items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h3 className="break-words font-black text-slate-900 dark:text-white">{platform.name}</h3>
+                        <p className="mt-1 break-all text-xs text-slate-500">{platform.detail}</p>
                       </div>
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-black uppercase ${statusClass[platform.status]}`}>{platform.status}</span>
+                      <span className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-black uppercase ${statusClass[platform.status]}`}>{platform.status}</span>
                     </div>
                   </article>
                 ))}
@@ -265,13 +264,13 @@ export default function AdvertisingHub() {
             </section>
 
             {(activeSection === 'dashboard' || activeSection === 'campaigns') && (
-              <section className="overflow-hidden rounded-3xl bg-white shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+              <section className="min-w-0 overflow-hidden rounded-3xl bg-white shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
                 <div className="border-b border-slate-200 p-5 dark:border-slate-800">
-                  <h2 className="text-xl font-black text-slate-950 dark:text-white">Meta campaigns</h2>
-                  <p className="text-sm text-slate-500">Resultados y control de campañas. Los cambios requieren confirmación.</p>
+                  <h2 className="break-words text-xl font-black text-slate-950 dark:text-white">Meta campaigns</h2>
+                  <p className="break-words text-sm text-slate-500">Resultados y control de campañas. Los cambios requieren confirmación.</p>
                 </div>
-                <div className="overflow-x-auto">
-                  <table className="min-w-full text-sm">
+                <div className="max-w-full overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
+                  <table className="min-w-[980px] text-sm">
                     <thead className="bg-slate-50 text-left text-xs uppercase text-slate-500 dark:bg-slate-950">
                       <tr>
                         <th className="px-5 py-3">Campaign</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Daily budget</th><th className="px-5 py-3">Spend</th><th className="px-5 py-3">Clicks</th><th className="px-5 py-3">CTR</th><th className="px-5 py-3">Registrations</th><th className="px-5 py-3">Actions</th>
@@ -284,8 +283,8 @@ export default function AdvertisingHub() {
 
                         return (
                           <tr key={campaign.id}>
-                            <td className="px-5 py-4"><p className="font-bold text-slate-900 dark:text-white">{campaign.name}</p><p className="text-xs text-slate-500">{campaign.objective || campaign.id}</p></td>
-                            <td className="px-5 py-4 text-xs font-bold">{campaign.effective_status || campaign.status || '—'}</td>
+                            <td className="max-w-[260px] px-5 py-4"><p className="break-words font-bold text-slate-900 dark:text-white">{campaign.name}</p><p className="break-all text-xs text-slate-500">{campaign.objective || campaign.id}</p></td>
+                            <td className="whitespace-nowrap px-5 py-4 text-xs font-bold">{campaign.effective_status || campaign.status || '—'}</td>
                             <td className="px-5 py-4">
                               {campaign.daily_budget == null ? <span className="text-xs text-slate-500">Ad set budget</span> : (
                                 <div className="flex min-w-[180px] items-center gap-2">
@@ -294,11 +293,11 @@ export default function AdvertisingHub() {
                                 </div>
                               )}
                             </td>
-                            <td className="px-5 py-4 font-semibold">{money(campaign.metrics?.spend, campaign.currency || 'MXN')}</td>
-                            <td className="px-5 py-4">{number(campaign.metrics?.clicks)}</td>
-                            <td className="px-5 py-4">{Number(campaign.metrics?.ctr || 0).toFixed(2)}%</td>
-                            <td className="px-5 py-4">{number(campaign.metrics?.registrations)}</td>
-                            <td className="px-5 py-4">
+                            <td className="whitespace-nowrap px-5 py-4 font-semibold">{money(campaign.metrics?.spend, campaign.currency || 'MXN')}</td>
+                            <td className="whitespace-nowrap px-5 py-4">{number(campaign.metrics?.clicks)}</td>
+                            <td className="whitespace-nowrap px-5 py-4">{Number(campaign.metrics?.ctr || 0).toFixed(2)}%</td>
+                            <td className="whitespace-nowrap px-5 py-4">{number(campaign.metrics?.registrations)}</td>
+                            <td className="whitespace-nowrap px-5 py-4">
                               <button type="button" disabled={busy} onClick={() => toggleCampaign(campaign)} className={`rounded-lg px-3 py-2 text-xs font-black text-white disabled:opacity-50 ${active ? 'bg-amber-600' : 'bg-lime-700'}`}>
                                 {busy ? 'Guardando…' : active ? 'Pausar' : 'Activar'}
                               </button>
@@ -314,9 +313,9 @@ export default function AdvertisingHub() {
             )}
 
             {activeSection !== 'dashboard' && activeSection !== 'campaigns' && (
-              <section className="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-8 text-center dark:border-slate-700 dark:bg-slate-900/60">
-                <h2 className="text-xl font-black text-slate-900 dark:text-white">{activeSectionInfo.label}</h2>
-                <p className="mx-auto mt-2 max-w-xl text-sm text-slate-500">{activeSectionInfo.description} Este módulo se conectará al mismo modelo interno de campañas y métricas.</p>
+              <section className="min-w-0 rounded-3xl border border-dashed border-slate-300 bg-white/60 p-8 text-center dark:border-slate-700 dark:bg-slate-900/60">
+                <h2 className="break-words text-xl font-black text-slate-900 dark:text-white">{activeSectionInfo.label}</h2>
+                <p className="mx-auto mt-2 max-w-xl break-words text-sm text-slate-500">{activeSectionInfo.description} Este módulo se conectará al mismo modelo interno de campañas y métricas.</p>
               </section>
             )}
           </main>


### PR DESCRIPTION
## Summary
- prevent the Advertising Hub shell and main grid from overflowing the mobile viewport
- make header actions wrap cleanly on narrow screens
- switch navigation to a compact responsive grid on mobile
- constrain long account IDs and campaign text
- keep the campaigns table horizontally scrollable inside its own card

## Risk
Low. This is a frontend-only responsive layout change. Campaign API behavior and data mutations are unchanged.

## Smoke
- open `/admin/marketing?section=campaigns` on a phone-sized viewport
- confirm the page itself does not scroll horizontally
- confirm the campaign table scrolls horizontally inside the card
- confirm refresh, back, budget and status controls remain usable

## Rollback
Revert this pull request. No database or backend changes are included.