### PR TITLE
Fix AI moderation retry loop

### DIFF
--- a/backend/app/Console/Commands/ModeratePendingAds.php
+++ b/backend/app/Console/Commands/ModeratePendingAds.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Jobs\ModerateAdWithAI;
 use App\Models\Ad;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 
 class ModeratePendingAds extends Command
@@ -20,6 +21,17 @@ class ModeratePendingAds extends Command
             return self::FAILURE;
         }
 
+        $providerError = Cache::get('ai_moderation:provider_unavailable');
+        if ($providerError) {
+            $this->warn('AI moderation provider is temporarily unavailable: ' . $providerError);
+            return self::SUCCESS;
+        }
+
+        if ((string) config('services.gemini.api_key') === '') {
+            $this->warn('AI moderation skipped because GEMINI_API_KEY is not configured.');
+            return self::SUCCESS;
+        }
+
         $limit = max(1, min(500, (int) $this->option('limit')));
 
         $ads = Ad::query()
@@ -27,23 +39,14 @@ class ModeratePendingAds extends Command
                 $query->where('status', 'pending')
                     ->where(function ($pending) {
                         $pending->whereNull('ai_moderation_status')
-                            ->orWhere('ai_moderation_status', 'queued')
-                            ->orWhere(function ($failed) {
-                                $failed->where('ai_moderation_status', 'failed')
-                                    ->where('updated_at', '<=', now()->subHour());
-                            });
+                            ->orWhere('ai_moderation_status', 'queued');
                     });
             })
             ->orWhere(function ($query) {
                 $query->where('status', 'archived')
-                    ->where(function ($hidden) {
-                        $hidden->where(function ($stuck) {
-                            $stuck->whereIn('ai_moderation_status', ['queued', 'processing'])
-                                ->where('updated_at', '<=', now()->subMinutes(15));
-                        })->orWhere(function ($failed) {
-                            $failed->where('ai_moderation_status', 'failed')
-                                ->where('updated_at', '<=', now()->subHour());
-                        });
+                    ->where(function ($stuck) {
+                        $stuck->where('ai_moderation_status', 'queued')
+                            ->where('updated_at', '<=', now()->subMinutes(15));
                     });
             })
             ->orderByRaw('COALESCE(moderation_submitted_at, created_at) ASC')

--- a/backend/app/Jobs/ModerateAdWithAI.php
+++ b/backend/app/Jobs/ModerateAdWithAI.php
@@ -48,6 +48,16 @@ class ModerateAdWithAI implements ShouldQueue, ShouldBeUnique
             return;
         }
 
+        $providerError = Cache::get('ai_moderation:provider_unavailable');
+        if ($providerError) {
+            $this->leaveForManualReview(
+                $ad,
+                'La moderación automática está temporalmente desactivada por un problema de configuración del proveedor.',
+                'provider_error'
+            );
+            return;
+        }
+
         $covers->ensureCover($ad);
         $ad->refresh();
 
@@ -60,7 +70,12 @@ class ModerateAdWithAI implements ShouldQueue, ShouldBeUnique
 
         $apiKey = (string) config('services.gemini.api_key');
         if ($apiKey === '') {
-            $this->leaveForManualReview($ad, 'La moderación automática no está configurada: falta GEMINI_API_KEY.', 'failed');
+            Cache::put('ai_moderation:provider_unavailable', 'GEMINI_API_KEY is not configured.', now()->addHour());
+            $this->leaveForManualReview(
+                $ad,
+                'La moderación automática no está configurada. El anuncio requiere revisión manual.',
+                'provider_error'
+            );
             return;
         }
 
@@ -102,7 +117,33 @@ class ModerateAdWithAI implements ShouldQueue, ShouldBeUnique
                 ]);
 
             if (! $response->successful()) {
-                throw new \RuntimeException('Gemini HTTP ' . $response->status());
+                $providerMessage = trim((string) $response->json('error.message', ''));
+                $isInvalidKey = $response->status() === 400
+                    && str_contains(strtolower($providerMessage), 'api key not valid');
+
+                if ($isInvalidKey) {
+                    Cache::put(
+                        'ai_moderation:provider_unavailable',
+                        'Gemini API key is invalid.',
+                        now()->addHour()
+                    );
+
+                    Log::critical('AI moderation disabled because Gemini API key is invalid', [
+                        'ad_id' => $ad->id,
+                        'status' => $response->status(),
+                    ]);
+
+                    $this->leaveForManualReview(
+                        $ad,
+                        'La moderación automática está temporalmente desactivada por un problema de configuración. El anuncio requiere revisión manual.',
+                        'provider_error'
+                    );
+                    return;
+                }
+
+                throw new \RuntimeException(
+                    'Gemini HTTP ' . $response->status() . ($providerMessage !== '' ? ': ' . $providerMessage : '')
+                );
             }
 
             $rawText = (string) $response->json('candidates.0.content.parts.0.text', '');


### PR DESCRIPTION
## Исправлено
- архивные объявления со статусом `failed` больше не ставятся в очередь повторно;
- добавлен circuit breaker для невалидного или отсутствующего Gemini API key;
- при ошибке ключа используется отдельный технический статус `provider_error`;
- планировщик прекращает массовую постановку задач на час после ошибки провайдера;
- зависшие задачи `queued` могут безопасно восстанавливаться, но `failed` не повторяются автоматически.

Это предотвращает повторное накопление сотен архивных объявлений и одинаковых HTTP 400 ошибок.