### PR TITLE
Expire abandoned pending payments automatically

### DIFF
--- a/backend/app/Console/Commands/ExpirePendingPayments.php
+++ b/backend/app/Console/Commands/ExpirePendingPayments.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class ExpirePendingPayments extends Command
+{
+    protected $signature = 'payments:expire-pending
+                            {--hours=24 : Pending payment lifetime in hours}
+                            {--limit=500 : Maximum payments to expire per run}';
+
+    protected $description = 'Expire stale pending payments that have no webhook confirmation';
+
+    public function handle(): int
+    {
+        $hours = max(1, (int) $this->option('hours'));
+        $limit = max(1, min(5000, (int) $this->option('limit')));
+        $cutoff = now()->subHours($hours);
+
+        $ids = DB::table('payments')
+            ->where('status', 'pending')
+            ->whereNull('webhook_payload')
+            ->where('created_at', '<=', $cutoff)
+            ->orderBy('id')
+            ->limit($limit)
+            ->pluck('id');
+
+        if ($ids->isEmpty()) {
+            $this->info('Expired 0 stale pending payment(s).');
+            return self::SUCCESS;
+        }
+
+        $expired = DB::table('payments')
+            ->whereIn('id', $ids)
+            ->where('status', 'pending')
+            ->whereNull('webhook_payload')
+            ->update([
+                'status' => 'expired',
+                'updated_at' => now(),
+            ]);
+
+        $this->info("Expired {$expired} stale pending payment(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -40,6 +40,12 @@ Schedule::call(function () {
     }
 })->hourly();
 
+// Close abandoned Clip payment attempts after 24 hours. A webhook payload always
+// wins, so confirmed or provider-processed payments are never expired here.
+Schedule::command('payments:expire-pending --hours=24 --limit=500')
+    ->hourly()
+    ->withoutOverlapping(10);
+
 // Process the oldest moderation submissions first. The command only dispatches jobs,
 // so the scheduler stays responsive even when image analysis is slow.
 Schedule::command('ads:moderate-pending --limit=100')


### PR DESCRIPTION
## Исправлено
- добавлена команда `payments:expire-pending`;
- незавершённые платежи без webhook автоматически получают статус `expired` через 24 часа;
- обработка ограничена пакетами по 500 записей;
- команда запускается каждый час без параллельного повторного запуска;
- подтверждённые или обработанные провайдером операции с webhook не затрагиваются.

## Проверка
После развёртывания:
- `php artisan payments:expire-pending --hours=24 --limit=500`
- `php artisan schedule:list`

Миграция базы не требуется.